### PR TITLE
Add burn-history output layer

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2518,10 +2518,10 @@ or false:
             [clojure.string        :as str]
             [gridfire.crown-fire   :refer [m->ft]]
             [gridfire.fetch        :as fetch]
-            [gridfire.fire-spread  :refer [run-fire-spread]]
+            [gridfire.fire-spread  :refer [get-neighbors in-bounds? run-fire-spread]]
+            [gridfire.perturbation :as perturbation]
             [gridfire.spec.config  :as spec]
             [gridfire.utils.random :refer [my-rand-int my-rand-nth]]
-            [gridfire.perturbation :as perturbation]
             [magellan.core         :refer [make-envelope
                                            matrix-to-raster
                                            register-new-crs-definitions-from-properties-file!
@@ -2606,10 +2606,47 @@ or false:
 (defn kebab->snake [s]
   (str/replace s #"-" "_"))
 
-(defn layer-matrix [fire-spread-results layer]
-  (let [kw (->> (str (name layer) "-matrix")
-                keyword)]
-   (get fire-spread-results kw)))
+(defn min->hour [t]
+  (int (quot t 60)))
+
+(defn previous-active-perimeter?
+  [[i j :as here] matrix]
+  (let [num-rows (m/row-count matrix)
+        num-cols (m/column-count matrix)]
+   (and
+    (= (m/mget matrix i j) -1.0)
+    (->> (get-neighbors here)
+         (filter #(in-bounds? num-rows num-cols %))
+         (map #(apply m/mget matrix %))
+         (some pos?)))))
+
+(defn to-color-map-values [burn-time-matrix global-clock]
+  (m/emap-indexed (fn [here burn-time]
+                    (let [delta-hours (->> (- global-clock burn-time)
+                                           min->hour)]
+                      (cond
+                        (previous-active-perimeter? here burn-time-matrix) 201
+                        (= burn-time -1.0)                                 200
+                        (< 0 delta-hours 5)                                delta-hours
+                        (>= delta-hours 5)                                 5
+                        :else                                              0)))
+                  burn-time-matrix))
+
+(defn layer-matrix
+  [{:keys [global-clock burn-time-matrix] :as fire-spread-results} layer]
+  (if (= layer :burn-history)
+    (to-color-map-values burn-time-matrix global-clock)
+    (let [kw (->> (str (name layer) "-matrix")
+                  keyword)]
+      (get fire-spread-results kw))))
+
+(defn layer-snapshot [burn-time-matrix layer-matrix  t]
+  (m/emap (fn [layer-value burn-time]
+            (if (<= burn-time t)
+              layer-value
+              0))
+          layer-matrix
+          burn-time-matrix))
 
 (defn process-output-layers-timestep!
   [{:keys [output-layers output-geotiffs? output-pngs?]}
@@ -2618,12 +2655,9 @@ or false:
    simulation-id]
   (doseq [[layer timestep] output-layers
           output-time      (range 0 (inc global-clock) timestep)]
-    (let [filtered-matrix (m/emap (fn [layer-value burn-time]
-                                    (if (<= burn-time output-time)
-                                      layer-value
-                                      0.0))
-                                  (layer-matrix fire-spread-results layer)
-                                  burn-time-matrix)
+    (let [filtered-matrix (layer-snapshot burn-time-matrix
+                                          (layer-matrix fire-spread-results layer)
+                                          output-time)
           layer-name      (-> (name layer)
                               kebab->snake)]
       (when output-geotiffs?

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -9,10 +9,10 @@
             [clojure.string        :as str]
             [gridfire.crown-fire   :refer [m->ft]]
             [gridfire.fetch        :as fetch]
-            [gridfire.fire-spread  :refer [run-fire-spread]]
+            [gridfire.fire-spread  :refer [get-neighbors in-bounds? run-fire-spread]]
+            [gridfire.perturbation :as perturbation]
             [gridfire.spec.config  :as spec]
             [gridfire.utils.random :refer [my-rand-int my-rand-nth]]
-            [gridfire.perturbation :as perturbation]
             [magellan.core         :refer [make-envelope
                                            matrix-to-raster
                                            register-new-crs-definitions-from-properties-file!
@@ -97,10 +97,47 @@
 (defn kebab->snake [s]
   (str/replace s #"-" "_"))
 
-(defn layer-matrix [fire-spread-results layer]
-  (let [kw (->> (str (name layer) "-matrix")
-                keyword)]
-   (get fire-spread-results kw)))
+(defn min->hour [t]
+  (int (quot t 60)))
+
+(defn previous-active-perimeter?
+  [[i j :as here] matrix]
+  (let [num-rows (m/row-count matrix)
+        num-cols (m/column-count matrix)]
+   (and
+    (= (m/mget matrix i j) -1.0)
+    (->> (get-neighbors here)
+         (filter #(in-bounds? num-rows num-cols %))
+         (map #(apply m/mget matrix %))
+         (some pos?)))))
+
+(defn to-color-map-values [burn-time-matrix global-clock]
+  (m/emap-indexed (fn [here burn-time]
+                    (let [delta-hours (->> (- global-clock burn-time)
+                                           min->hour)]
+                      (cond
+                        (previous-active-perimeter? here burn-time-matrix) 201
+                        (= burn-time -1.0)                                 200
+                        (< 0 delta-hours 5)                                delta-hours
+                        (>= delta-hours 5)                                 5
+                        :else                                              0)))
+                  burn-time-matrix))
+
+(defn layer-matrix
+  [{:keys [global-clock burn-time-matrix] :as fire-spread-results} layer]
+  (if (= layer :burn-history)
+    (to-color-map-values burn-time-matrix global-clock)
+    (let [kw (->> (str (name layer) "-matrix")
+                  keyword)]
+      (get fire-spread-results kw))))
+
+(defn layer-snapshot [burn-time-matrix layer-matrix  t]
+  (m/emap (fn [layer-value burn-time]
+            (if (<= burn-time t)
+              layer-value
+              0))
+          layer-matrix
+          burn-time-matrix))
 
 (defn process-output-layers-timestep!
   [{:keys [output-layers output-geotiffs? output-pngs?]}
@@ -109,12 +146,9 @@
    simulation-id]
   (doseq [[layer timestep] output-layers
           output-time      (range 0 (inc global-clock) timestep)]
-    (let [filtered-matrix (m/emap (fn [layer-value burn-time]
-                                    (if (<= burn-time output-time)
-                                      layer-value
-                                      0.0))
-                                  (layer-matrix fire-spread-results layer)
-                                  burn-time-matrix)
+    (let [filtered-matrix (layer-snapshot burn-time-matrix
+                                          (layer-matrix fire-spread-results layer)
+                                          output-time)
           layer-name      (-> (name layer)
                               kebab->snake)]
       (when output-geotiffs?

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -111,9 +111,9 @@
          (map #(apply m/mget matrix %))
          (some pos?)))))
 
-(defn to-color-map-values [burn-time-matrix global-clock]
+(defn to-color-map-values [burn-time-matrix current-clock]
   (m/emap-indexed (fn [here burn-time]
-                    (let [delta-hours (->> (- global-clock burn-time)
+                    (let [delta-hours (->> (- current-clock burn-time)
                                            min->hour)]
                       (cond
                         (previous-active-perimeter? here burn-time-matrix) 201
@@ -124,9 +124,9 @@
                   burn-time-matrix))
 
 (defn layer-matrix
-  [{:keys [global-clock burn-time-matrix] :as fire-spread-results} layer]
+  [{:keys [burn-time-matrix] :as fire-spread-results} layer current-clock]
   (if (= layer :burn-history)
-    (to-color-map-values burn-time-matrix global-clock)
+    (to-color-map-values burn-time-matrix current-clock)
     (let [kw (->> (str (name layer) "-matrix")
                   keyword)]
       (get fire-spread-results kw))))
@@ -147,7 +147,7 @@
   (doseq [[layer timestep] output-layers
           output-time      (range 0 (inc global-clock) timestep)]
     (let [filtered-matrix (layer-snapshot burn-time-matrix
-                                          (layer-matrix fire-spread-results layer)
+                                          (layer-matrix fire-spread-results layer output-time)
                                           output-time)
           layer-name      (-> (name layer)
                               kebab->snake)]

--- a/src/gridfire/spec/output.clj
+++ b/src/gridfire/spec/output.clj
@@ -14,11 +14,11 @@
 (s/def ::fire-spread ::type)
 (s/def ::flame-length ::type)
 (s/def ::fire-line-intensity ::type)
-(s/def ::burn-time ::type)
+(s/def ::burn-history ::type)
 
 (s/def ::output-layers
   (common/one-or-more-keys
    [::fire-spread
     ::flame-length
     ::fire-line-intensity
-    ::burn-time]))
+    ::burn-history]))


### PR DESCRIPTION
----

We are now supporting an output that has these value mappings.

Encoding taken from geotiff served on pyregence

color-map-entry(#000000,   0, 0.0, "nodata")
color-map-entry(#ff0000,   1, 1.0, "1 hour ago")
color-map-entry(#ff9900,   2, 1.0, "2 hours ago")
color-map-entry(#ffff00,   3, 1.0, "3 hours ago")
color-map-entry(#999999,   4, 1.0, "4 hours ago")
color-map-entry(#484848,   5, 0.5, "5+ hours ago")
color-map-entry(#000000, 200, 0.5, "Previously burned")
color-map-entry(#440044, 201, 1.0, "Previous active perimeter");


#