### PR TITLE
Add crown fire spotting percent

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2648,6 +2648,15 @@ ignition probability.
           :let           [new-count (inc (m/mget firebrand-count-matrix x y))]]
     (m/mset! firebrand-count-matrix x y new-count)))
 
+(defn spot-fire? [{:keys [spotting rand-gen]} crown-fire?]
+  (when crown-fire?
+    (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
+      (let [p (if (seq spot-percent)
+                (let [[lo hi] spot-percent]
+                  (random-float lo hi rand-gen))
+                spot-percent)]
+           (>= p (random-float 0.0 1.0 rand-gen))))))
+
 (defn spread-firebrands
   "Returns a sequence of key value pairs where
   key: [x y] locations of the cell
@@ -2661,8 +2670,8 @@ ignition probability.
            fire-spread-matrix
            fire-line-intensity-matrix
            flame-length-matrix]}
-   {:keys [cell crown-fire?]}]
-  (when crown-fire?
+   {:keys [cell fire-line-intensity crown-fire?] :as ignition-event}]
+  (when (spot-fire? config crown-fire?)
     (let [{:keys
            [wind-speed-20ft
             temperature
@@ -3854,18 +3863,18 @@ type to *:pixel*.
 Gridfire supports spot fires.
 To turn on spot ignitions include the key *spotting* at the top level of the
 config file. The value is a map containg these required entries:
-- ambient-gas-density: float
-- specific-heat-gas: float
-- num-firebrands: number of firebrands each torched tree will produce
-- decay-constant: positive number
-- crown-fire-spotting-percent: probability a crown fire ignition will spot fires.
-  Expects a float between 0.0 and 1.0.
+- *ambient-gas-density*: float
+- *specific-heat-gas*: float
+- *num-firebrands*: number of firebrands each torched tree will produce
+- *decay-constant*: positive number
+- *crown-fire-spotting-percent*: probability a crown fire ignition will spot fires.
 
 #+begin_src clojure
 {:spotting {:ambient-gas-density 1.1     ;(kgm^-3)
             :specific-heat-gas   1121.0  ;(KJkg^-1 K^-1)
             :num-firebrands      50
-            :decay-constant      0.005}}
+            :decay-constant      0.005
+            :crown-fire-spotting-percent 0.5}}
 #+end_src
 
 

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2651,7 +2651,7 @@ ignition probability.
 (defn spot-fire? [{:keys [spotting rand-gen]} crown-fire?]
   (when crown-fire?
     (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
-      (let [p (if (seq spot-percent)
+      (let [p (if (vector? spot-percent)
                 (let [[lo hi] spot-percent]
                   (random-float lo hi rand-gen))
                 spot-percent)]

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3863,6 +3863,7 @@ type to *:pixel*.
 Gridfire supports spot fires.
 To turn on spot ignitions include the key *spotting* at the top level of the
 config file. The value is a map containg these required entries:
+
 - *ambient-gas-density*: float
 - *specific-heat-gas*: float
 - *num-firebrands*: number of firebrands each torched tree will produce

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2670,7 +2670,7 @@ ignition probability.
            fire-spread-matrix
            fire-line-intensity-matrix
            flame-length-matrix]}
-   {:keys [cell fire-line-intensity crown-fire?] :as ignition-event}]
+   {:keys [cell crown-fire?]}]
   (when (spot-fire? config crown-fire?)
     (let [{:keys
            [wind-speed-20ft

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2655,7 +2655,7 @@ ignition probability.
                 (let [[lo hi] spot-percent]
                   (random-float lo hi rand-gen))
                 spot-percent)]
-           (>= p (random-float 0.0 1.0 rand-gen))))))
+        (>= p (random-float 0.0 1.0 rand-gen))))))
 
 (defn spread-firebrands
   "Returns a sequence of key value pairs where

--- a/src/gridfire/spec/spotting.clj
+++ b/src/gridfire/spec/spotting.clj
@@ -2,10 +2,21 @@
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::ambient-gas-density float?)
+
 (s/def ::specific-heat-gas float?)
+
 (s/def ::num-firebrands int?)
+
+(s/def ::ordered (fn [[lo hi]] (<= lo hi)))
+
+(s/def ::crown-fire-spotting-percent (s/or
+                                      :scalar (s/and float?
+                                                     #(<= 0.0 % 1.0))
+                                      :range (s/and (s/tuple float? float?)
+                                                    ::ordered)))
 
 (s/def ::spotting
   (s/keys :req-un [::ambient-gas-density
-                   ::specific-heat-gas
-                   ::num-firebrands]))
+                   ::crown-fire-spotting-percent
+                   ::num-firebrands
+                   ::specific-heat-gas]))

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -227,7 +227,7 @@
                 (let [[lo hi] spot-percent]
                   (random-float lo hi rand-gen))
                 spot-percent)]
-           (>= p (random-float 0.0 1.0 rand-gen))))))
+        (>= p (random-float 0.0 1.0 rand-gen))))))
 
 (defn spread-firebrands
   "Returns a sequence of key value pairs where

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -223,7 +223,7 @@
 (defn spot-fire? [{:keys [spotting rand-gen]} crown-fire?]
   (when crown-fire?
     (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
-      (let [p (if (seq spot-percent)
+      (let [p (if (vector? spot-percent)
                 (let [[lo hi] spot-percent]
                   (random-float lo hi rand-gen))
                 spot-percent)]

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -242,7 +242,7 @@
            fire-spread-matrix
            fire-line-intensity-matrix
            flame-length-matrix]}
-   {:keys [cell fire-line-intensity crown-fire?] :as ignition-event}]
+   {:keys [cell crown-fire?]}]
   (when (spot-fire? config crown-fire?)
     (let [{:keys
            [wind-speed-20ft

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -220,6 +220,15 @@
           :let           [new-count (inc (m/mget firebrand-count-matrix x y))]]
     (m/mset! firebrand-count-matrix x y new-count)))
 
+(defn spot-fire? [{:keys [spotting rand-gen]} crown-fire?]
+  (when crown-fire?
+    (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
+      (let [p (if (seq spot-percent)
+                (let [[lo hi] spot-percent]
+                  (random-float lo hi rand-gen))
+                spot-percent)]
+           (>= p (random-float 0.0 1.0 rand-gen))))))
+
 (defn spread-firebrands
   "Returns a sequence of key value pairs where
   key: [x y] locations of the cell
@@ -233,8 +242,8 @@
            fire-spread-matrix
            fire-line-intensity-matrix
            flame-length-matrix]}
-   {:keys [cell crown-fire?]}]
-  (when crown-fire?
+   {:keys [cell fire-line-intensity crown-fire?] :as ignition-event}]
+  (when (spot-fire? config crown-fire?)
     (let [{:keys
            [wind-speed-20ft
             temperature

--- a/test/gridfire/spec/spotting_test.clj
+++ b/test/gridfire/spec/spotting_test.clj
@@ -12,17 +12,11 @@
 
 (deftest crown-fire-spotting-percent-test
   (testing "scalar"
-    (let [config 0.1]
-
-      (is (s/valid? ::spotting/crown-fire-spotting-percent config))))
+    (is (s/valid? ::spotting/crown-fire-spotting-percent 0.1)))
 
   (testing "range"
-   (let [config [0.1 0.8]]
-
-     (is (s/valid? ::spotting/crown-fire-spotting-percent config))))
+    (is (s/valid? ::spotting/crown-fire-spotting-percent [0.1 0.8])))
 
   (testing "invalid range"
-    (let [config [0.8 0.1]]
-
-      (is (not (s/valid? ::spotting/crown-fire-spotting-percent config))
-          "first value is larger than the second"))))
+    (is (not (s/valid? ::spotting/crown-fire-spotting-percent [0.8 0.1]))
+        "first value should not be larger than the second")))

--- a/test/gridfire/spec/spotting_test.clj
+++ b/test/gridfire/spec/spotting_test.clj
@@ -1,0 +1,28 @@
+(ns gridfire.spec.spotting-test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer [deftest is testing]]
+            [gridfire.spec.spotting :as spotting]))
+
+(deftest spotting-test
+  (let [config {:ambient-gas-density         1.0
+                :crown-fire-spotting-percent [0.1 0.8]
+                :num-firebrands              10
+                :specific-heat-gas           0.1}]
+    (is (s/valid? ::spotting/spotting config))))
+
+(deftest crown-fire-spotting-percent-test
+  (testing "scalar"
+    (let [config 0.1]
+
+      (is (s/valid? ::spotting/crown-fire-spotting-percent config))))
+
+  (testing "range"
+   (let [config [0.1 0.8]]
+
+     (is (s/valid? ::spotting/crown-fire-spotting-percent config))))
+
+  (testing "invalid range"
+    (let [config [0.8 0.1]]
+
+      (is (not (s/valid? ::spotting/crown-fire-spotting-percent config))
+          "first value is larger than the second"))))


### PR DESCRIPTION
Crown fire spotting percent 

The `:crown-fire-spotting-percent` key is added to the config.edn
under `:spotting`. It controls spotting initiation from passive/active
crown fire pixels, meaning if it is set to 1.0 then 1 out of every 100
pixels that burn as crown fire will initiate the spotting algorithm.