### PR TITLE
Allow users to specify num-firebrand range

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1838,25 +1838,25 @@ pseudo-code lays out the steps taken in this procedure:
 (ns gridfire.fire-spread
   (:require [clojure.core.matrix           :as m]
             [clojure.core.matrix.operators :as mop]
-            [gridfire.common               :refer [extract-constants
+            [gridfire.common               :refer [burnable-fuel-model?
+                                                   burnable?
+                                                   extract-constants
                                                    fuel-moisture
-                                                   in-bounds?
-                                                   burnable-fuel-model?
-                                                   burnable?]]
-            [gridfire.crown-fire           :refer [crown-fire-eccentricity
-                                                   crown-fire-line-intensity
-                                                   cruz-crown-fire-spread
-                                                   van-wagner-crown-fire-initiation?]]
-            [gridfire.fuel-models          :refer [build-fuel-model moisturize]]
-            [gridfire.surface-fire         :refer [anderson-flame-depth
-                                                   byram-fire-line-intensity
-                                                   byram-flame-length
-                                                   rothermel-surface-fire-spread-any
-                                                   rothermel-surface-fire-spread-max
-                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                   wind-adjustment-factor]]
-            [gridfire.perturbation         :as perturbation]
-            [gridfire.spotting             :as spot]))
+                                                   in-bounds?]]
+            [gridfire.crown-fire          :refer [crown-fire-eccentricity
+                                                  crown-fire-line-intensity
+                                                  cruz-crown-fire-spread
+                                                  van-wagner-crown-fire-initiation?]]
+            [gridfire.fuel-models         :refer [build-fuel-model moisturize]]
+            [gridfire.perturbation        :as perturbation]
+            [gridfire.spotting            :as spot]
+            [gridfire.surface-fire        :refer [anderson-flame-depth
+                                                  byram-fire-line-intensity
+                                                  byram-flame-length
+                                                  rothermel-surface-fire-spread-any
+                                                  rothermel-surface-fire-spread-max
+                                                  rothermel-surface-fire-spread-no-wind-no-slope
+                                                  wind-adjustment-factor]]))
 
 (m/set-current-implementation :vectorz)
 
@@ -2389,7 +2389,7 @@ the direction perpendicular to the wind.
                                      in-bounds?
                                      burnable?]]
             [gridfire.crown-fire :refer [ft->m]]
-            [gridfire.utils.random :refer [random-float]]
+            [gridfire.utils.random :refer [random-float my-rand-int-range]]
             [gridfire.conversion :as convert]
             [kixi.stats.distribution :as distribution]))
 
@@ -2438,21 +2438,30 @@ the direction perpendicular to the wind.
     (+ (* 1.47 (Math/pow fire-line-intensity 0.54) (Math/pow wind-speed-20ft -0.55)) 1.14)
     (- (* 1.32 (Math/pow fire-line-intensity 0.26) (Math/pow wind-speed-20ft 0.11)) 0.02)))
 
+(defn- sample-num-firebrands
+  [{:keys [num-firebrands]} rand-gen]
+  (if (map? num-firebrands)
+    (let [{:keys [lo hi]} num-firebrands
+          l               (if (vector? lo) (my-rand-int-range rand-gen lo) lo)
+          h               (if (vector? hi) (my-rand-int-range rand-gen hi) hi)]
+      (my-rand-int-range rand-gen [l h]))
+    num-firebrands))
+
 (defn sample-wind-dir-deltas
   "Returns a sequence of [x y] distances (meters) that firebrands land away
   from a torched cell at i j where:
   x: parallel to the wind
   y: perpendicular to the wind (positive values are to the right of wind direction)
   "
-  [{:keys [spotting random-seed] :as config}
+  [{:keys [spotting rand-gen random-seed] :as config}
    fire-line-intensity-matrix
    wind-speed-20ft
    temperature
    [i j]]
   (let [{:keys
-         [num-firebrands
-          ambient-gas-density
+         [ambient-gas-density
           specific-heat-gas]} spotting
+        num-firebrands        (sample-num-firebrands spotting rand-gen)
         intensity             (convert/Btu-ft-s->kW-m (m/mget fire-line-intensity-matrix i j))
         froude                (froude-number intensity
                                              wind-speed-20ft
@@ -3365,6 +3374,11 @@ or false:
   [min-val max-val rand-generator]
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))
+
+(defn my-rand-int-range
+  [rand-generator [min-val max-val]]
+  (let [range (- max-val min-val)]
+    (+ min-val (int (my-rand rand-generator range)))))
 #+end_src
 
 * Configuration File
@@ -3873,7 +3887,7 @@ config file. The value is a map containg these required entries:
 #+begin_src clojure
 {:spotting {:ambient-gas-density 1.1     ;(kgm^-3)
             :specific-heat-gas   1121.0  ;(KJkg^-1 K^-1)
-            :num-firebrands      50
+            :num-firebrands      [10 50]
             :decay-constant      0.005
             :crown-fire-spotting-percent 0.5}}
 #+end_src

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -2,25 +2,25 @@
 (ns gridfire.fire-spread
   (:require [clojure.core.matrix           :as m]
             [clojure.core.matrix.operators :as mop]
-            [gridfire.common               :refer [extract-constants
+            [gridfire.common               :refer [burnable-fuel-model?
+                                                   burnable?
+                                                   extract-constants
                                                    fuel-moisture
-                                                   in-bounds?
-                                                   burnable-fuel-model?
-                                                   burnable?]]
-            [gridfire.crown-fire           :refer [crown-fire-eccentricity
-                                                   crown-fire-line-intensity
-                                                   cruz-crown-fire-spread
-                                                   van-wagner-crown-fire-initiation?]]
-            [gridfire.fuel-models          :refer [build-fuel-model moisturize]]
-            [gridfire.surface-fire         :refer [anderson-flame-depth
-                                                   byram-fire-line-intensity
-                                                   byram-flame-length
-                                                   rothermel-surface-fire-spread-any
-                                                   rothermel-surface-fire-spread-max
-                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                   wind-adjustment-factor]]
-            [gridfire.perturbation         :as perturbation]
-            [gridfire.spotting             :as spot]))
+                                                   in-bounds?]]
+            [gridfire.crown-fire          :refer [crown-fire-eccentricity
+                                                  crown-fire-line-intensity
+                                                  cruz-crown-fire-spread
+                                                  van-wagner-crown-fire-initiation?]]
+            [gridfire.fuel-models         :refer [build-fuel-model moisturize]]
+            [gridfire.perturbation        :as perturbation]
+            [gridfire.spotting            :as spot]
+            [gridfire.surface-fire        :refer [anderson-flame-depth
+                                                  byram-fire-line-intensity
+                                                  byram-flame-length
+                                                  rothermel-surface-fire-spread-any
+                                                  rothermel-surface-fire-spread-max
+                                                  rothermel-surface-fire-spread-no-wind-no-slope
+                                                  wind-adjustment-factor]]))
 
 (m/set-current-implementation :vectorz)
 

--- a/src/gridfire/spec/spotting.clj
+++ b/src/gridfire/spec/spotting.clj
@@ -5,8 +5,6 @@
 
 (s/def ::specific-heat-gas float?)
 
-(s/def ::num-firebrands int?)
-
 (s/def ::ordered (fn [[lo hi]] (<= lo hi)))
 
 (s/def ::crown-fire-spotting-percent (s/or
@@ -14,6 +12,35 @@
                                                      #(<= 0.0 % 1.0))
                                       :range (s/and (s/tuple float? float?)
                                                     ::ordered)))
+
+(s/def ::lo (s/or
+             :scalar int?
+             :range (s/and (s/tuple int? int?)
+                           ::ordered)))
+
+(s/def ::hi (s/or
+             :scalar int?
+             :range (s/and (s/tuple int? int?)
+                           ::ordered)))
+
+(defn- increasing? [s]
+  (if (seq s)
+    (let [[f & rest] s]
+      (if (and rest (> f (first rest)))
+        false
+        (recur rest)))
+    true))
+
+(s/def ::valid-numbrand-ranges
+  (fn [{:keys [lo hi]}]
+    (let [[_ l] lo
+          [_ h] hi]
+      (increasing? (flatten (conj [] l h))))))
+
+(s/def ::num-firebrands (s/or
+                         :scalar int?
+                         :map (s/and (s/keys :req-un [::lo ::hi])
+                                     ::valid-numbrand-ranges)))
 
 (s/def ::spotting
   (s/keys :req-un [::ambient-gas-density

--- a/src/gridfire/utils/random.clj
+++ b/src/gridfire/utils/random.clj
@@ -18,4 +18,9 @@
   [min-val max-val rand-generator]
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))
+
+(defn my-rand-int-range
+  [rand-generator [min-val max-val]]
+  (let [range (- max-val min-val)]
+    (+ min-val (int (my-rand rand-generator range)))))
 ;; utils-random ends here

--- a/test/gridfire/spec/spotting_test.clj
+++ b/test/gridfire/spec/spotting_test.clj
@@ -20,3 +20,32 @@
   (testing "invalid range"
     (is (not (s/valid? ::spotting/crown-fire-spotting-percent [0.8 0.1]))
         "first value should not be larger than the second")))
+
+(deftest num-firebrands-test
+  (testing "scalar"
+    (is (s/valid? ::spotting/num-firebrands 10)))
+
+  (testing "range"
+    (is (s/valid? ::spotting/num-firebrands {:lo 1 :hi 10})
+        "lo and hi can both be scalar")
+
+    (is (s/valid? ::spotting/num-firebrands {:lo [1 2] :hi [9 10]})
+        "lo and hi can both be ranges")
+
+    (is (s/valid? ::spotting/num-firebrands {:lo 1 :hi [9 10]})
+        "lo and hi can either be scalar or range"))
+
+  (testing "edge cases"
+    (is (s/valid? ::spotting/num-firebrands {:lo 1 :hi [1 2]})
+        "edge of ranges can overlap")
+
+    (is (s/valid? ::spotting/num-firebrands {:lo [1 2] :hi [2 3]})
+        "edge of ranges can overlap"))
+
+  (testing "invalid range"
+
+    (is (not (s/valid? ::spotting/num-firebrands {:lo 10 :hi 1 }))
+        "lo should not be higher than hi")
+
+    (is (not (s/valid? ::spotting/num-firebrands {:lo [1 3] :hi [2 3]}))
+        "should not have overlapping ranges")))


### PR DESCRIPTION
The number of firebrands a crown fire ignition event can produce can now be sampled from a range