### PR TITLE
Add surface fire spotting

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2657,14 +2657,45 @@ ignition probability.
           :let           [new-count (inc (m/mget firebrand-count-matrix x y))]]
     (m/mset! firebrand-count-matrix x y new-count)))
 
-(defn spot-fire? [{:keys [spotting rand-gen]} crown-fire?]
-  (when crown-fire?
-    (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
-      (let [p (if (vector? spot-percent)
-                (let [[lo hi] spot-percent]
-                  (random-float lo hi rand-gen))
-                spot-percent)]
-        (>= p (random-float 0.0 1.0 rand-gen))))))
+(defn- in-range?
+  [[min max] fuel-model-number]
+  (<= min fuel-model-number max))
+
+(defn surface-spot-percent
+  [fuel-range-percents fuel-model-number]
+  (reduce (fn [acc [fuel-range percent]]
+            (if (in-range? fuel-range fuel-model-number)
+              percent
+              acc))
+          0.0
+          fuel-range-percents))
+
+(defn surface-fire-spot-fire?
+  "Expects surface-fire-spotting config to be a sequence of tuples of
+  ranges [lo hi] and spottting percent. The range represents the range (inclusive)
+  of fuel model numbers that the spotting percent is set to.
+  [[[1 140] 0.0]
+  [[141 149] 1.0]
+  [[150 256] 1.0]]"
+  [{:keys [spotting rand-gen]} {:keys [landfire-layers]} [i j]]
+  (let [fuel-range-percents (get-in spotting [:surface-fire-spotting :spotting-percent])
+        fuel-model-raster   (:fuel-model landfire-layers)
+        fuel-model-number   (int (m/mget fuel-model-raster i j))
+        spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number)]
+    (>= spot-percent (random-float 0.0 1.0 rand-gen))))
+
+(defn crown-spot-fire? [{:keys [spotting rand-gen]}]
+  (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
+    (let [p (if (seq spot-percent)
+              (let [[lo hi] spot-percent]
+                (random-float lo hi rand-gen))
+              spot-percent)]
+      (>= p (random-float 0.0 1.0 rand-gen)))))
+
+(defn spot-fire? [config constants crown-fire? here]
+  (if crown-fire?
+    (crown-spot-fire? config)
+    (surface-fire-spot-fire? config constants here)))
 
 (defn spread-firebrands
   "Returns a sequence of key value pairs where

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3913,16 +3913,25 @@ config file. The value is a map containg these required entries:
 - *specific-heat-gas*: float
 - *num-firebrands*: number of firebrands each torched tree will produce
 - *decay-constant*: positive number
-- *crown-fire-spotting-percent*: probability a crown fire ignition will spot fires.
+- *crown-fire-spotting-percent*: probability a crown fire ignition will spot fires
+
+You may also choose to include surface fire spotting. This behavior is
+controlled by including the following mappings under the `:spotting`
+configuration:
+
+- *surface-fire-spotting*: a vector of fuel range and percent pairs
+  where the fuel range is a tuple of integers representing the fuel model
+  numbers and the percent is the percentage of surface fire igntion
+  events that will spot fires.
 
 #+begin_src clojure
 {:spotting {:ambient-gas-density 1.1     ;(kgm^-3)
             :specific-heat-gas   1121.0  ;(KJkg^-1 K^-1)
             :num-firebrands      [10 50]
             :decay-constant      0.005
-            :crown-fire-spotting-percent 0.5}}
+            :crown-fire-spotting-percent 0.
+            :surface-fires-spotting [[1 100] 1.0]}}
 #+end_src
-
 
 * Example Configuration files
 

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2666,8 +2666,8 @@ ignition probability.
   [fuel-range-percents fuel-model-number rand-gen]
   (reduce (fn [acc [fuel-range percent]]
             (if (in-range? fuel-range fuel-model-number)
-              (if (vector? fuel-range)
-                (my-rand-range rand-gen fuel-range)
+              (if (vector? percent)
+                (my-rand-range rand-gen percent)
                 percent)
               acc))
           0.0
@@ -2743,8 +2743,8 @@ ignition probability.
                (let [[i j] cell
                      t     (spot-ignition-time global-clock
                                                (ft->m (m/mget flame-length-matrix i j))
-                                               (convert/mph->mps wind-speed-20ft))
-                     [[x y] [t spot-ignition-p]]])))
+                                               (convert/mph->mps wind-speed-20ft))]
+                 [[x y] [t spot-ignition-p]])))
            (remove nil?)))))
 #+end_src
 * User Interface

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2686,7 +2686,7 @@ ignition probability.
 
 (defn crown-spot-fire? [{:keys [spotting rand-gen]}]
   (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
-    (let [p (if (seq spot-percent)
+    (let [p (if (vector? spot-percent)
               (let [[lo hi] spot-percent]
                 (random-float lo hi rand-gen))
               spot-percent)]

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2389,7 +2389,7 @@ the direction perpendicular to the wind.
                                      in-bounds?
                                      burnable?]]
             [gridfire.crown-fire :refer [ft->m]]
-            [gridfire.utils.random :refer [random-float my-rand-int-range]]
+            [gridfire.utils.random :refer [random-float my-rand-range]]
             [gridfire.conversion :as convert]
             [kixi.stats.distribution :as distribution]))
 
@@ -2442,9 +2442,9 @@ the direction perpendicular to the wind.
   [{:keys [num-firebrands]} rand-gen]
   (if (map? num-firebrands)
     (let [{:keys [lo hi]} num-firebrands
-          l               (if (vector? lo) (my-rand-int-range rand-gen lo) lo)
-          h               (if (vector? hi) (my-rand-int-range rand-gen hi) hi)]
-      (my-rand-int-range rand-gen [l h]))
+          l               (if (vector? lo) (my-rand-range rand-gen lo) lo)
+          h               (if (vector? hi) (my-rand-range rand-gen hi) hi)]
+      (my-rand-range rand-gen [l h]))
     num-firebrands))
 
 (defn sample-wind-dir-deltas
@@ -3410,10 +3410,12 @@ or false:
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))
 
-(defn my-rand-int-range
+(defn my-rand-range
   [rand-generator [min-val max-val]]
   (let [range (- max-val min-val)]
-    (+ min-val (int (my-rand rand-generator range)))))
+    (+ min-val (if (and (int? min-val) (int? max-val))
+                 (int (my-rand rand-generator range))
+                 (my-rand rand-generator range)))))
 #+end_src
 
 * Configuration File

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2661,11 +2661,13 @@ ignition probability.
   [[min max] fuel-model-number]
   (<= min fuel-model-number max))
 
-(defn surface-spot-percent
-  [fuel-range-percents fuel-model-number]
+(defn- surface-spot-percent
+  [fuel-range-percents fuel-model-number rand-gen]
   (reduce (fn [acc [fuel-range percent]]
             (if (in-range? fuel-range fuel-model-number)
-              percent
+              (if (vector? fuel-range)
+                (my-rand-range rand-gen fuel-range)
+                percent)
               acc))
           0.0
           fuel-range-percents))
@@ -2681,7 +2683,7 @@ ignition probability.
   (let [fuel-range-percents (get-in spotting [:surface-fire-spotting :spotting-percent])
         fuel-model-raster   (:fuel-model landfire-layers)
         fuel-model-number   (int (m/mget fuel-model-raster i j))
-        spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number)]
+        spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number rand-gen)]
     (>= spot-percent (random-float 0.0 1.0 rand-gen))))
 
 (defn crown-spot-fire? [{:keys [spotting rand-gen]}]

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2711,7 +2711,7 @@ ignition probability.
            fire-line-intensity-matrix
            flame-length-matrix]}
    {:keys [cell crown-fire?]}]
-  (when (spot-fire? config crown-fire?)
+  (when (spot-fire? config constants crown-fire? cell)
     (let [{:keys
            [wind-speed-20ft
             temperature

--- a/src/gridfire/spec/spotting.clj
+++ b/src/gridfire/spec/spotting.clj
@@ -5,23 +5,23 @@
 
 (s/def ::specific-heat-gas float?)
 
-(s/def ::ordered (fn [[lo hi]] (<= lo hi)))
+(s/def ::ordered-range (fn [[lo hi]] (<= lo hi)))
 
 (s/def ::crown-fire-spotting-percent (s/or
                                       :scalar (s/and float?
                                                      #(<= 0.0 % 1.0))
                                       :range (s/and (s/tuple float? float?)
-                                                    ::ordered)))
+                                                    ::ordered-range)))
 
 (s/def ::lo (s/or
              :scalar int?
              :range (s/and (s/tuple int? int?)
-                           ::ordered)))
+                           ::ordered-range)))
 
 (s/def ::hi (s/or
              :scalar int?
              :range (s/and (s/tuple int? int?)
-                           ::ordered)))
+                           ::ordered-range)))
 
 (defn- increasing? [s]
   (if (seq s)
@@ -42,8 +42,25 @@
                          :map (s/and (s/keys :req-un [::lo ::hi])
                                      ::valid-numbrand-ranges)))
 
+(s/def ::valid-fuel-range (fn [[lo hi]] (<= 1 lo hi 204)))
+
+(s/def ::fuel-number-range (s/and (s/tuple int? int?)
+                                  ::valid-fuel-range
+                                  ::ordered-range))
+
+(s/def ::fuel-percent-pair (s/tuple ::fuel-number-range (s/or :scalar float?
+                                                              :range (s/tuple float? float?))))
+
+
+(s/def ::spotting-percent
+  (s/coll-of ::fuel-percent-pair :kind vector?))
+
+(s/def ::surface-fire-spotting
+  (s/keys :req-un [::spotting-percent]))
+
 (s/def ::spotting
   (s/keys :req-un [::ambient-gas-density
                    ::crown-fire-spotting-percent
                    ::num-firebrands
-                   ::specific-heat-gas]))
+                   ::specific-heat-gas]
+          :opt-un [::surface-fire-spotting]))

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -232,11 +232,13 @@
   [[min max] fuel-model-number]
   (<= min fuel-model-number max))
 
-(defn surface-spot-percent
-  [fuel-range-percents fuel-model-number]
+(defn- surface-spot-percent
+  [fuel-range-percents fuel-model-number rand-gen]
   (reduce (fn [acc [fuel-range percent]]
             (if (in-range? fuel-range fuel-model-number)
-              percent
+              (if (vector? fuel-range)
+                (my-rand-range rand-gen fuel-range)
+                percent)
               acc))
           0.0
           fuel-range-percents))
@@ -252,7 +254,7 @@
   (let [fuel-range-percents (get-in spotting [:surface-fire-spotting :spotting-percent])
         fuel-model-raster   (:fuel-model landfire-layers)
         fuel-model-number   (int (m/mget fuel-model-raster i j))
-        spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number)]
+        spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number rand-gen)]
     (>= spot-percent (random-float 0.0 1.0 rand-gen))))
 
 (defn crown-spot-fire? [{:keys [spotting rand-gen]}]

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -236,8 +236,8 @@
   [fuel-range-percents fuel-model-number rand-gen]
   (reduce (fn [acc [fuel-range percent]]
             (if (in-range? fuel-range fuel-model-number)
-              (if (vector? fuel-range)
-                (my-rand-range rand-gen fuel-range)
+              (if (vector? percent)
+                (my-rand-range rand-gen percent)
                 percent)
               acc))
           0.0

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -257,7 +257,7 @@
 
 (defn crown-spot-fire? [{:keys [spotting rand-gen]}]
   (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
-    (let [p (if (seq spot-percent)
+    (let [p (if (vector? spot-percent)
               (let [[lo hi] spot-percent]
                 (random-float lo hi rand-gen))
               spot-percent)]

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -282,7 +282,7 @@
            fire-line-intensity-matrix
            flame-length-matrix]}
    {:keys [cell crown-fire?]}]
-  (when (spot-fire? config crown-fire?)
+  (when (spot-fire? config constants crown-fire? cell)
     (let [{:keys
            [wind-speed-20ft
             temperature

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -228,14 +228,45 @@
           :let           [new-count (inc (m/mget firebrand-count-matrix x y))]]
     (m/mset! firebrand-count-matrix x y new-count)))
 
-(defn spot-fire? [{:keys [spotting rand-gen]} crown-fire?]
-  (when crown-fire?
-    (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
-      (let [p (if (vector? spot-percent)
-                (let [[lo hi] spot-percent]
-                  (random-float lo hi rand-gen))
-                spot-percent)]
-        (>= p (random-float 0.0 1.0 rand-gen))))))
+(defn- in-range?
+  [[min max] fuel-model-number]
+  (<= min fuel-model-number max))
+
+(defn surface-spot-percent
+  [fuel-range-percents fuel-model-number]
+  (reduce (fn [acc [fuel-range percent]]
+            (if (in-range? fuel-range fuel-model-number)
+              percent
+              acc))
+          0.0
+          fuel-range-percents))
+
+(defn surface-fire-spot-fire?
+  "Expects surface-fire-spotting config to be a sequence of tuples of
+  ranges [lo hi] and spottting percent. The range represents the range (inclusive)
+  of fuel model numbers that the spotting percent is set to.
+  [[[1 140] 0.0]
+  [[141 149] 1.0]
+  [[150 256] 1.0]]"
+  [{:keys [spotting rand-gen]} {:keys [landfire-layers]} [i j]]
+  (let [fuel-range-percents (get-in spotting [:surface-fire-spotting :spotting-percent])
+        fuel-model-raster   (:fuel-model landfire-layers)
+        fuel-model-number   (int (m/mget fuel-model-raster i j))
+        spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number)]
+    (>= spot-percent (random-float 0.0 1.0 rand-gen))))
+
+(defn crown-spot-fire? [{:keys [spotting rand-gen]}]
+  (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
+    (let [p (if (seq spot-percent)
+              (let [[lo hi] spot-percent]
+                (random-float lo hi rand-gen))
+              spot-percent)]
+      (>= p (random-float 0.0 1.0 rand-gen)))))
+
+(defn spot-fire? [config constants crown-fire? here]
+  (if crown-fire?
+    (crown-spot-fire? config)
+    (surface-fire-spot-fire? config constants here)))
 
 (defn spread-firebrands
   "Returns a sequence of key value pairs where

--- a/src/gridfire/spotting.clj
+++ b/src/gridfire/spotting.clj
@@ -7,7 +7,7 @@
                                      in-bounds?
                                      burnable?]]
             [gridfire.crown-fire :refer [ft->m]]
-            [gridfire.utils.random :refer [random-float my-rand-int-range]]
+            [gridfire.utils.random :refer [random-float my-rand-range]]
             [gridfire.conversion :as convert]
             [kixi.stats.distribution :as distribution]))
 
@@ -60,9 +60,9 @@
   [{:keys [num-firebrands]} rand-gen]
   (if (map? num-firebrands)
     (let [{:keys [lo hi]} num-firebrands
-          l               (if (vector? lo) (my-rand-int-range rand-gen lo) lo)
-          h               (if (vector? hi) (my-rand-int-range rand-gen hi) hi)]
-      (my-rand-int-range rand-gen [l h]))
+          l               (if (vector? lo) (my-rand-range rand-gen lo) lo)
+          h               (if (vector? hi) (my-rand-range rand-gen hi) hi)]
+      (my-rand-range rand-gen [l h]))
     num-firebrands))
 
 (defn sample-wind-dir-deltas

--- a/src/gridfire/utils/random.clj
+++ b/src/gridfire/utils/random.clj
@@ -19,8 +19,10 @@
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))
 
-(defn my-rand-int-range
+(defn my-rand-range
   [rand-generator [min-val max-val]]
   (let [range (- max-val min-val)]
-    (+ min-val (int (my-rand rand-generator range)))))
+    (+ min-val (if (and (int? min-val) (int? max-val))
+                 (int (my-rand rand-generator range))
+                 (my-rand rand-generator range)))))
 ;; utils-random ends here

--- a/test/gridfire/spec/spotting_test.clj
+++ b/test/gridfire/spec/spotting_test.clj
@@ -54,14 +54,6 @@
         "edge of ranges can overlap"))
 
   (testing "invalid range"
-<<<<<<< HEAD
-
-    (is (not (s/valid? ::spotting/num-firebrands {:lo 10 :hi 1 }))
-        "lo should not be higher than hi")
-
-    (is (not (s/valid? ::spotting/num-firebrands {:lo [1 3] :hi [2 3]}))
-        "should not have overlapping ranges")))
-=======
     (let [config {:lo 10
                   :hi 1 }]
       (is (not (s/valid? ::spotting/num-firebrands config))
@@ -86,4 +78,3 @@
                   [[169 204] [0.2 0.4]]]]
 
       (is (s/valid? ::spotting/surface-fire-spotting-percent config)))))
->>>>>>> add surface fire spotting

--- a/test/gridfire/spec/spotting_test.clj
+++ b/test/gridfire/spec/spotting_test.clj
@@ -4,11 +4,22 @@
             [gridfire.spec.spotting :as spotting]))
 
 (deftest spotting-test
-  (let [config {:ambient-gas-density         1.0
-                :crown-fire-spotting-percent [0.1 0.8]
-                :num-firebrands              10
-                :specific-heat-gas           0.1}]
-    (is (s/valid? ::spotting/spotting config))))
+  (testing "required"
+   (let [config {:ambient-gas-density         1.0
+                 :crown-fire-spotting-percent [0.1 0.8]
+                 :num-firebrands              10
+                 :specific-heat-gas           0.1}]
+     (is (s/valid? ::spotting/spotting config))))
+
+  (testing "optional surface-fire-spotting"
+    (let [config {:ambient-gas-density         1.0
+                  :crown-fire-spotting-percent [0.1 0.8]
+                  :num-firebrands              10
+                  :specific-heat-gas           0.1
+                  :surface-fire-spotting       {:spotting-percent [[[1   149] 1.0]
+                                                                   [[150 169] 2.0]
+                                                                   [[169 204] 3.0]]}}]
+      (is (s/valid? ::spotting/spotting config)))))
 
 (deftest crown-fire-spotting-percent-test
   (testing "scalar"
@@ -43,9 +54,36 @@
         "edge of ranges can overlap"))
 
   (testing "invalid range"
+<<<<<<< HEAD
 
     (is (not (s/valid? ::spotting/num-firebrands {:lo 10 :hi 1 }))
         "lo should not be higher than hi")
 
     (is (not (s/valid? ::spotting/num-firebrands {:lo [1 3] :hi [2 3]}))
         "should not have overlapping ranges")))
+=======
+    (let [config {:lo 10
+                  :hi 1 }]
+      (is (not (s/valid? ::spotting/num-firebrands config))
+          "lo syhould not be higher than hi"))
+
+    (let [config {:lo [1 3]
+                  :hi [2 3]}]
+      (is (not (s/valid? ::spotting/num-firebrands config))
+          "should not have overlapping ranges"))))
+
+(deftest surface-fire-spotting-test
+  (testing "scalar percents"
+    (let [config [[[1   149] 1.0]
+                  [[150 169] 2.0]
+                  [[169 204] 3.0]]]
+
+      (is (s/valid? ::spotting/surface-fire-spotting-percent config))))
+
+  (testing "range percents"
+    (let [config [[[1   149] [1.0 2.0]]
+                  [[150 169] [3.0 4.0]]
+                  [[169 204] [0.2 0.4]]]]
+
+      (is (s/valid? ::spotting/surface-fire-spotting-percent config)))))
+>>>>>>> add surface fire spotting

--- a/test/gridfire/spotting_test.clj
+++ b/test/gridfire/spotting_test.clj
@@ -67,3 +67,22 @@
           (is (close-to-zero dy))
 
           (is (= H dx)))))))
+
+(deftest surface-spot-percents
+  (testing "expected ranges"
+    (let [spot-percents [[[1 140] 1.0]
+                         [[141 149] 2.0]
+                         [[150 256] 3.0]]]
+
+      (is (= 1.0 (spotting/surface-spot-percent spot-percents 5)))
+
+      (is (= 2.0 (spotting/surface-spot-percent spot-percents 143)))
+
+      (is (= 3.0 (spotting/surface-spot-percent spot-percents 155)))))
+
+  (testing "overlapping ranges"
+    (let [spot-percents [[[1 140] 1.0]
+                         [[130 149] 2.0]]]
+
+      (is (= 2.0 (spotting/surface-spot-percent spot-percents 133))
+          "should overwite percents of previous range in the sequence"))))


### PR DESCRIPTION
This PR enables surface fires to spot.
- Spec for `:spotting` now includes `:surface-spotting` which contains
  a map for surface spotting configurations.
- Added `:spotting-percent` which controls the probability of spot
  ignition for specified range of fuel models.