### PR TITLE
Add critical spotting intensity

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2677,12 +2677,14 @@ ignition probability.
   [[[1 140] 0.0]
   [[141 149] 1.0]
   [[150 256] 1.0]]"
-  [{:keys [spotting rand-gen]} {:keys [landfire-layers]} [i j]]
-  (let [fuel-range-percents (get-in spotting [:surface-fire-spotting :spotting-percent])
-        fuel-model-raster   (:fuel-model landfire-layers)
-        fuel-model-number   (int (m/mget fuel-model-raster i j))
-        spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number)]
-    (>= spot-percent (random-float 0.0 1.0 rand-gen))))
+  [{:keys [spotting rand-gen]} {:keys [landfire-layers]} [i j] fire-line-intensity]
+  (let [{:keys [surface-fire-spotting]} spotting]
+    (when (> fire-line-intensity (:critical-fire-line-intensity surface-fire-spotting))
+      (let [fuel-range-percents (:spotting-percent surface-fire-spotting)
+            fuel-model-raster   (:fuel-model landfire-layers)
+            fuel-model-number   (int (m/mget fuel-model-raster i j))
+            spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number)]
+        (>= spot-percent (random-float 0.0 1.0 rand-gen))))))
 
 (defn crown-spot-fire? [{:keys [spotting rand-gen]}]
   (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
@@ -2692,10 +2694,10 @@ ignition probability.
               spot-percent)]
       (>= p (random-float 0.0 1.0 rand-gen)))))
 
-(defn spot-fire? [config constants crown-fire? here]
+(defn spot-fire? [config constants crown-fire? here fire-line-intensity]
   (if crown-fire?
     (crown-spot-fire? config)
-    (surface-fire-spot-fire? config constants here)))
+    (surface-fire-spot-fire? config constants here fire-line-intensity)))
 
 (defn spread-firebrands
   "Returns a sequence of key value pairs where
@@ -2710,8 +2712,8 @@ ignition probability.
            fire-spread-matrix
            fire-line-intensity-matrix
            flame-length-matrix]}
-   {:keys [cell crown-fire?]}]
-  (when (spot-fire? config constants crown-fire? cell)
+   {:keys [cell fire-line-intensity crown-fire?]}]
+  (when (spot-fire? config constants crown-fire? cell fire-line-intensity)
     (let [{:keys
            [wind-speed-20ft
             temperature

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3918,21 +3918,25 @@ config file. The value is a map containg these required entries:
 - *crown-fire-spotting-percent*: probability a crown fire ignition will spot fires
 
 You may also choose to include surface fire spotting. This behavior is
-controlled by including the following mappings under the `:spotting`
+controlled by including the following mappings under the *:spotting*
 configuration:
 
-- *surface-fire-spotting*: a vector of fuel range and percent pairs
-  where the fuel range is a tuple of integers representing the fuel model
-  numbers and the percent is the percentage of surface fire igntion
-  events that will spot fires.
+- *surface-fire-spotting*: a map containing these required entries:
+  - *spotting-percent*: a vector of fuel range and percent pairs where
+    the fuel range is a tuple of integers representing the fuel model
+    numbers and the percent is the percentage of surface fire igntion
+    events that will spot fires
+  - *critical-fire-line-intensity*: the fireline intensity below which
+    surface fire spotting does not occur
 
 #+begin_src clojure
-{:spotting {:ambient-gas-density 1.1     ;(kgm^-3)
-            :specific-heat-gas   1121.0  ;(KJkg^-1 K^-1)
-            :num-firebrands      [10 50]
-            :decay-constant      0.005
+{:spotting {:ambient-gas-density         1.1    ;(kgm^-3)
+            :specific-heat-gas           1121.0 ;(KJkg^-1 K^-1)
+            :num-firebrands              [10 50]
+            :decay-constant              0.005
             :crown-fire-spotting-percent 0.
-            :surface-fires-spotting [[1 100] 1.0]}}
+            :surface-fires-spotting      {:spotting-percent             [[1 100] 1.0]
+                                          :critical-fire-line-intensity 2000}}} ;(kW/m)
 #+end_src
 
 * Example Configuration files

--- a/src/gridfire/spec/spotting.clj
+++ b/src/gridfire/spec/spotting.clj
@@ -51,12 +51,13 @@
 (s/def ::fuel-percent-pair (s/tuple ::fuel-number-range (s/or :scalar float?
                                                               :range (s/tuple float? float?))))
 
-
 (s/def ::spotting-percent
   (s/coll-of ::fuel-percent-pair :kind vector?))
 
+(s/def ::critical-fire-line-intensity float?)
+
 (s/def ::surface-fire-spotting
-  (s/keys :req-un [::spotting-percent]))
+  (s/keys :req-un [::spotting-percent ::critical-fire-line-intensity]))
 
 (s/def ::spotting
   (s/keys :req-un [::ambient-gas-density


### PR DESCRIPTION
The critical spotting intensity is the fire line intensity below which
surface fire spotting does not occur.