### PR TITLE
Add write-bin-to-geotiff-config-file!

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3259,7 +3259,7 @@ or false:
   (when output-binary?
     (let [output-name (format "toa_0001_%05d.bin" (inc simulation))]
       (binary/write-matrices-as-binary [{:ttype  :float
-                                         :matrix burn-time-matrix}
+                                         :matrix (m/emap #(if (pos? %) (* 60 %) -1.0) burn-time-matrix)}
                                         {:ttype  :float
                                          :matrix flame-length-matrix}
                                         {:ttype  :float

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3259,7 +3259,7 @@ or false:
   (when output-binary?
     (let [output-name (format "toa_0001_%05d.bin" (inc simulation))]
       (binary/write-matrices-as-binary [{:ttype  :float
-                                         :matrix (m/emap #(if (pos? %) (* 60 %) -1.0) burn-time-matrix)}
+                                         :matrix (m/emap #(if (neg? %) -1.0 (* 60 %)) burn-time-matrix)}
                                         {:ttype  :float
                                          :matrix flame-length-matrix}
                                         {:ttype  :float

--- a/src/gridfire/binary_output.clj
+++ b/src/gridfire/binary_output.clj
@@ -60,7 +60,7 @@
                                  :data  (non-zero-data matrix)})
                               matrices)]
     (with-open [out (DataOutputStream. (io/output-stream file-name))]
-      (.writeInt out (int num-burned-cells))                   ; Int32
+      (.writeInt out (int num-burned-cells))                                  ; Int32
       (doseq [x (get-in (first data) [:data :x])] (.writeInt out (int x)))    ; Int32
       (doseq [y (get-in (first data) [:data :y])] (.writeInt out (int y)))    ; Int32
       (doseq [d data
@@ -104,21 +104,22 @@
 ;;-----------------------------------------------------------------------------
 
 (defn build-post-process-config
-  [{:keys [cell-size simulations output-binary]} raster]
+  [{:keys [cell-size simulations output-binary]} raster csv-filename]
   (array-map
-   "NX"                (:width raster)
-   "NY"                (:height raster)
-   "NCASES"            simulations
-   "XLLCORNER"         (:lowerleftx raster)
-   "YLLCORNER"         (:lowerlefty raster)
-   "CELLSIZE"          (convert/ft->m cell-size)
-   "NUM_TIMESTEPS"     (:num-timesteps output-binary)
-   "DT"                (:dt output-binary)
-   "OUTPUTS_DIRECTORY" "/gridfire/output"
-   "POSTPROCESS_TYPE"  1
-   "BINARY_FILE_TYPE"  2
-   "PATH_TO_GDAL"      "/usr/bin/gdalinfo"
-   "SCRATCH"           "scratch"))
+   "NX"                       (:width raster)
+   "NY"                       (:height raster)
+   "NCASES"                   simulations
+   "XLLCORNER"                (:lowerleftx raster)
+   "YLLCORNER"                (:lowerlefty raster)
+   "CELLSIZE"                 (convert/ft->m cell-size)
+   "NUM_TIMESTEPS"            (:num-timesteps output-binary)
+   "DT"                       (:dt output-binary)
+   "OUTPUTS_DIRECTORY"        "'/gridfire/output'"
+   "FIRE_SIZE_STATS_FILENAME" (str "'" csv-filename "'")
+   "POSTPROCESS_TYPE"         1
+   "BINARY_FILE_TYPE"         2
+   "PATH_TO_GDAL"             "'/usr/bin/gdalinfo'"
+   "SCRATCH"                  "'scratch'"))
 
 (defn process-inputs [config]
   (map (fn [[k v]]
@@ -127,12 +128,12 @@
 
 (defn write-bin-to-geotiff-config-file!
   "Writes a configuration file for post processing binary files into geotiffs."
-  [file-name {:keys [output-directory] :as config} raster]
+  [file-name {:keys [output-directory] :as config} raster csv-filename]
   (with-open [out (io/writer (if output-directory
                                (s/join "/" [output-directory file-name])
                                file-name))]
     (.write out (str "&ELMFIRE_POST_INPUTS\n"))
-    (let [entries (-> (build-post-process-config config raster)
+    (let [entries (-> (build-post-process-config config raster csv-filename)
                       process-inputs)]
       (doseq [entry entries]
         (.write out entry)))))

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -275,7 +275,7 @@
   (when output-binary?
     (let [output-name (format "toa_0001_%05d.bin" (inc simulation))]
       (binary/write-matrices-as-binary [{:ttype  :float
-                                         :matrix burn-time-matrix}
+                                         :matrix (m/emap #(if (pos? %) (* 60 %) -1.0) burn-time-matrix)}
                                         {:ttype  :float
                                          :matrix flame-length-matrix}
                                         {:ttype  :float

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -275,7 +275,7 @@
   (when output-binary?
     (let [output-name (format "toa_0001_%05d.bin" (inc simulation))]
       (binary/write-matrices-as-binary [{:ttype  :float
-                                         :matrix (m/emap #(if (pos? %) (* 60 %) -1.0) burn-time-matrix)}
+                                         :matrix (m/emap #(if (neg? %) -1.0 (* 60 %)) burn-time-matrix)}
                                         {:ttype  :float
                                          :matrix flame-length-matrix}
                                         {:ttype  :float

--- a/src/gridfire/conversion.clj
+++ b/src/gridfire/conversion.clj
@@ -27,6 +27,11 @@
   [m]
   (* m 3.281))
 
+(defn ft->m
+  "Convert feet to meeter"
+  [ft]
+  (* 0.3048 ft))
+
 (defn mph->mps
   "Convert miles per hour to meters per second."
   [s]
@@ -49,3 +54,4 @@
   "Convert seconds to minutes."
   [s]
   (/ s 60))
+

--- a/src/gridfire/magellan_bridge.clj
+++ b/src/gridfire/magellan_bridge.clj
@@ -9,17 +9,19 @@
    post-processed raster values as a Clojure matrix using the core.matrix API
    along with all of the georeferencing information associated with this tile in a
    hash-map with the following form:
-  {:srid 900916,
-   :upperleftx -321043.875,
-   :upperlefty -1917341.5,
-   :width 486,
-   :height 534,
-   :scalex 2000.0,
-   :scaley -2000.0,
-   :skewx 0.0,
-   :skewy 0.0,
-   :numbands 10,
-   :matrix #vectorz/matrix Large matrix with shape: [10,534,486]}"
+   {:srid EPSG:32610,
+    :lowerleftx -2067000.0,
+    :lowerlefty 2459520.0,
+    :upperleftx -2067000.0,
+    :upperlefty 2460000.0,
+    :width 256,
+    :height 16,
+    :scalex 30.0,
+    :scaley -30.0,
+    :skewx 0.0,
+    :skewy 0.0,
+    :numbands 10,
+    :matrix #vectorz/matrix Large matrix with shape: [10,16,256]}"
   [file-path]
   (let [raster   (read-raster file-path)
         grid     (:grid raster)
@@ -28,6 +30,8 @@
         image    (:image r-info)
         envelope (:envelope r-info)]
     {:srid       (:srid r-info)
+     :lowerleftx (get-in envelope [:x :min])
+     :lowerlefty (get-in envelope [:y :min])
      :upperleftx (get-in envelope [:x :min])
      :upperlefty (get-in envelope [:y :max])
      :width      (:width image)


### PR DESCRIPTION
This function writes out the post processing file needed to post
process the binary files into geotiff files. This file is an input to
a fortran command line tool developed by Chris Lautenberger