### PR TITLE
Check for burnable cells in ignition-layer before running

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2335,22 +2335,23 @@ pseudo-code lays out the steps taken in this procedure:
                                                                  num-rows
                                                                  num-cols
                                                                  %)
-                                           non-zero-indices)
-        burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
-        firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
-        spread-rate-matrix         (initialize-matrix num-rows num-cols non-zero-indices)
-        fire-type-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
-        ignited-cells              (generate-ignited-cells constants fire-spread-matrix perimeter-indices)]
-    (run-loop constants
-              config
-              {:fire-spread-matrix         fire-spread-matrix
-               :spread-rate-matrix         spread-rate-matrix
-               :flame-length-matrix        flame-length-matrix
-               :fire-line-intensity-matrix fire-line-intensity-matrix
-               :firebrand-count-matrix     firebrand-count-matrix
-               :burn-time-matrix           burn-time-matrix
-               :fire-type-matrix           fire-type-matrix}
-              ignited-cells)))
+                                           non-zero-indices)]
+    (when (seq perimeter-indices)
+      (let [burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
+            firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
+            spread-rate-matrix         (initialize-matrix num-rows num-cols non-zero-indices)
+            fire-type-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
+            ignited-cells              (generate-ignited-cells constants fire-spread-matrix perimeter-indices)]
+       (run-loop constants
+                 config
+                 {:fire-spread-matrix         fire-spread-matrix
+                  :spread-rate-matrix         spread-rate-matrix
+                  :flame-length-matrix        flame-length-matrix
+                  :fire-line-intensity-matrix fire-line-intensity-matrix
+                  :firebrand-count-matrix     firebrand-count-matrix
+                  :burn-time-matrix           burn-time-matrix
+                  :fire-type-matrix           fire-type-matrix}
+                 ignited-cells)))))
 #+end_src
 
 This concludes our description of GridFire's raster-based fire spread

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2328,8 +2328,6 @@ pseudo-code lays out the steps taken in this procedure:
    {:keys [spotting] :as config}]
   (let [fire-spread-matrix         (first (m/mutable (:matrix initial-ignition-site)))
         non-zero-indices           (get-non-zero-indices fire-spread-matrix)
-        flame-length-matrix        (initialize-matrix num-rows num-cols non-zero-indices)
-        fire-line-intensity-matrix (initialize-matrix num-rows num-cols non-zero-indices)
         perimeter-indices          (filter #(burnable-neighbors? fire-spread-matrix
                                                                  (:fuel-model landfire-rasters)
                                                                  num-rows
@@ -2337,7 +2335,9 @@ pseudo-code lays out the steps taken in this procedure:
                                                                  %)
                                            non-zero-indices)]
     (when (seq perimeter-indices)
-      (let [burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
+      (let [flame-length-matrix        (initialize-matrix num-rows num-cols non-zero-indices)
+            fire-line-intensity-matrix (initialize-matrix num-rows num-cols non-zero-indices)
+            burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
             firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
             spread-rate-matrix         (initialize-matrix num-rows num-cols non-zero-indices)
             fire-type-matrix           (initialize-matrix num-rows num-cols non-zero-indices)

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -498,20 +498,21 @@
                                                                  num-rows
                                                                  num-cols
                                                                  %)
-                                           non-zero-indices)
-        burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
-        firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
-        spread-rate-matrix         (initialize-matrix num-rows num-cols non-zero-indices)
-        fire-type-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
-        ignited-cells              (generate-ignited-cells constants fire-spread-matrix perimeter-indices)]
-    (run-loop constants
-              config
-              {:fire-spread-matrix         fire-spread-matrix
-               :spread-rate-matrix         spread-rate-matrix
-               :flame-length-matrix        flame-length-matrix
-               :fire-line-intensity-matrix fire-line-intensity-matrix
-               :firebrand-count-matrix     firebrand-count-matrix
-               :burn-time-matrix           burn-time-matrix
-               :fire-type-matrix           fire-type-matrix}
-              ignited-cells)))
+                                           non-zero-indices)]
+    (when (seq perimeter-indices)
+      (let [burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
+            firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
+            spread-rate-matrix         (initialize-matrix num-rows num-cols non-zero-indices)
+            fire-type-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
+            ignited-cells              (generate-ignited-cells constants fire-spread-matrix perimeter-indices)]
+       (run-loop constants
+                 config
+                 {:fire-spread-matrix         fire-spread-matrix
+                  :spread-rate-matrix         spread-rate-matrix
+                  :flame-length-matrix        flame-length-matrix
+                  :fire-line-intensity-matrix fire-line-intensity-matrix
+                  :firebrand-count-matrix     firebrand-count-matrix
+                  :burn-time-matrix           burn-time-matrix
+                  :fire-type-matrix           fire-type-matrix}
+                 ignited-cells)))))
 ;; fire-spread-algorithm ends here

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -491,8 +491,6 @@
    {:keys [spotting] :as config}]
   (let [fire-spread-matrix         (first (m/mutable (:matrix initial-ignition-site)))
         non-zero-indices           (get-non-zero-indices fire-spread-matrix)
-        flame-length-matrix        (initialize-matrix num-rows num-cols non-zero-indices)
-        fire-line-intensity-matrix (initialize-matrix num-rows num-cols non-zero-indices)
         perimeter-indices          (filter #(burnable-neighbors? fire-spread-matrix
                                                                  (:fuel-model landfire-rasters)
                                                                  num-rows
@@ -500,7 +498,9 @@
                                                                  %)
                                            non-zero-indices)]
     (when (seq perimeter-indices)
-      (let [burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
+      (let [flame-length-matrix        (initialize-matrix num-rows num-cols non-zero-indices)
+            fire-line-intensity-matrix (initialize-matrix num-rows num-cols non-zero-indices)
+            burn-time-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
             firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
             spread-rate-matrix         (initialize-matrix num-rows num-cols non-zero-indices)
             fire-type-matrix           (initialize-matrix num-rows num-cols non-zero-indices)


### PR DESCRIPTION
I had came across a divide/zero error when processing a phi.tif with
zero burned cells. This is to catch that and make run-fire-spread
return nil if there are no burnable cells