### PR TITLE
Use random ignition ns in simulation runs

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1852,6 +1852,7 @@ pseudo-code lays out the steps taken in this procedure:
                                                   van-wagner-crown-fire-initiation?]]
             [gridfire.fuel-models         :refer [build-fuel-model moisturize]]
             [gridfire.perturbation        :as perturbation]
+            [gridfire.random-ignition     :as random-ignition]
             [gridfire.spotting            :as spot]
             [gridfire.surface-fire        :refer [anderson-flame-depth
                                                   byram-fire-line-intensity
@@ -1859,7 +1860,8 @@ pseudo-code lays out the steps taken in this procedure:
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]))
+                                                  wind-adjustment-factor]]
+            [gridfire.random-ignition :as random-ignition]))
 
 (m/set-current-implementation :vectorz)
 
@@ -2266,7 +2268,7 @@ pseudo-code lays out the steps taken in this procedure:
   [{:keys [landfire-rasters] :as constants} config]
   (run-fire-spread (assoc constants
                           :initial-ignition-site
-                          (select-random-ignition-site (:fuel-model landfire-rasters)))
+                          (random-ignition/ignition-site config (:fuel-model landfire-rasters)))
                    config))
 
 (defmethod run-fire-spread :ignition-point
@@ -3250,7 +3252,8 @@ or false:
   (mapv
    (fn [i]
      (let [initial-ignition-site (or ignition-layer
-                                     [(ignition-row i) (ignition-col i)])
+                                     (when (and (ignition-row i) (ignition-col i))
+                                      [(ignition-row i) (ignition-col i)]))
            temperature           (if (map? temperature) (:matrix temperature) (temperature i))
            wind-speed-20ft       (if (map? wind-speed-20ft) (:matrix wind-speed-20ft) (wind-speed-20ft i))
            wind-from-direction   (if (map? wind-from-direction) (:matrix wind-from-direction) (wind-from-direction i))

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1860,8 +1860,7 @@ pseudo-code lays out the steps taken in this procedure:
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]
-            [gridfire.random-ignition :as random-ignition]))
+                                                  wind-adjustment-factor]]))
 
 (m/set-current-implementation :vectorz)
 
@@ -2009,18 +2008,6 @@ pseudo-code lays out the steps taken in this procedure:
                                           crown-eccentricity landfire-rasters cell-size
                                           overflow-trajectory overflow-heat crown-type)))
           (get-neighbors here))))
-
-(defn select-random-ignition-site
-  [fuel-model-matrix]
-  (let [num-rows           (m/row-count    fuel-model-matrix)
-        num-cols           (m/column-count fuel-model-matrix)
-        fire-spread-matrix (m/zero-matrix num-rows num-cols)]
-    (loop [[i j :as ignition-site] (random-cell num-rows num-cols)]
-      (if (and (burnable-fuel-model? (m/mget fuel-model-matrix i j))
-               (burnable-neighbors? fire-spread-matrix fuel-model-matrix
-                                    num-rows num-cols ignition-site))
-        ignition-site
-        (recur (random-cell num-rows num-cols))))))
 
 (defn identify-ignition-events
   [ignited-cells timestep fire-spread-matrix]

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -280,7 +280,8 @@
   (mapv
    (fn [i]
      (let [initial-ignition-site (or ignition-layer
-                                     [(ignition-row i) (ignition-col i)])
+                                     (when (and (ignition-row i) (ignition-col i))
+                                      [(ignition-row i) (ignition-col i)]))
            temperature           (if (map? temperature) (:matrix temperature) (temperature i))
            wind-speed-20ft       (if (map? wind-speed-20ft) (:matrix wind-speed-20ft) (wind-speed-20ft i))
            wind-from-direction   (if (map? wind-from-direction) (:matrix wind-from-direction) (wind-from-direction i))

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -23,8 +23,7 @@
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]
-            [gridfire.random-ignition :as random-ignition]))
+                                                  wind-adjustment-factor]]))
 
 (m/set-current-implementation :vectorz)
 
@@ -172,18 +171,6 @@
                                           crown-eccentricity landfire-rasters cell-size
                                           overflow-trajectory overflow-heat crown-type)))
           (get-neighbors here))))
-
-(defn select-random-ignition-site
-  [fuel-model-matrix]
-  (let [num-rows           (m/row-count    fuel-model-matrix)
-        num-cols           (m/column-count fuel-model-matrix)
-        fire-spread-matrix (m/zero-matrix num-rows num-cols)]
-    (loop [[i j :as ignition-site] (random-cell num-rows num-cols)]
-      (if (and (burnable-fuel-model? (m/mget fuel-model-matrix i j))
-               (burnable-neighbors? fire-spread-matrix fuel-model-matrix
-                                    num-rows num-cols ignition-site))
-        ignition-site
-        (recur (random-cell num-rows num-cols))))))
 
 (defn identify-ignition-events
   [ignited-cells timestep fire-spread-matrix]

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -15,6 +15,7 @@
                                                   van-wagner-crown-fire-initiation?]]
             [gridfire.fuel-models         :refer [build-fuel-model moisturize]]
             [gridfire.perturbation        :as perturbation]
+            [gridfire.random-ignition     :as random-ignition]
             [gridfire.spotting            :as spot]
             [gridfire.surface-fire        :refer [anderson-flame-depth
                                                   byram-fire-line-intensity
@@ -22,7 +23,8 @@
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]))
+                                                  wind-adjustment-factor]]
+            [gridfire.random-ignition :as random-ignition]))
 
 (m/set-current-implementation :vectorz)
 
@@ -429,7 +431,7 @@
   [{:keys [landfire-rasters] :as constants} config]
   (run-fire-spread (assoc constants
                           :initial-ignition-site
-                          (select-random-ignition-site (:fuel-model landfire-rasters)))
+                          (random-ignition/ignition-site config (:fuel-model landfire-rasters)))
                    config))
 
 (defmethod run-fire-spread :ignition-point

--- a/test/gridfire/cli_test.clj
+++ b/test/gridfire/cli_test.clj
@@ -394,9 +394,11 @@
 
 (deftest igniton-mask-test
   (let [config  (merge test-config-base
-                       {:landfire-layers  landfire-layers-weather-test
-                        :random-ignition  {:ignition-mask {:type   :geotiff
-                                                           :source (in-file-path "weather-test/ignition_mask.tif")}
-                                           :edge-buffer   9843.0}})
-        results (run-simulation (dissoc config :ignition-row :ignition-col))]
+                       {:landfire-layers landfire-layers-weather-test
+                        :ignition-row    nil
+                        :ignition-col    nil
+                        :random-ignition {:ignition-mask {:type   :geotiff
+                                                          :source (in-file-path "weather-test/ignition_mask.tif")}
+                                          :edge-buffer   9843.0}})
+        results (run-simulation config)]
     (is (every? some? results))))


### PR DESCRIPTION
- dispatch value ignition-point now changed to ignition-points
  - This is will allow both a single ignition point and multiple ignition
    points to be handled by the same function.
- Refactor run-fire-spread, pulling out common code