### PR TITLE
Replace mean and standard deviation equations with elmfire's

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2390,7 +2390,7 @@ the direction perpendicular to the wind.
                                      in-bounds?
                                      burnable?]]
             [gridfire.crown-fire :refer [ft->m]]
-            [gridfire.utils.random :refer [random-float my-rand-int-range]]
+            [gridfire.utils.random :refer [random-float my-rand-range]]
             [gridfire.conversion :as convert]
             [kixi.stats.distribution :as distribution]))
 
@@ -2398,86 +2398,60 @@ the direction perpendicular to the wind.
 ;; Formulas
 ;;-----------------------------------------------------------------------------
 
-(defn froude-number
-  "Returns froude number given:
-  wind-speed-20ft: (ms^-1)
-  fire-line-intensity: (kWm^-1)
-  temperature: (Kelvin)
-  ambient-gas-density: (kgm^-3)
-  specific-heat-gas: (KJkg^-1 K^-1)"
-  [wind-speed-20ft fire-line-intensity temperature ambient-gas-density specific-heat-gas]
-  (let [g   9.81 ;(ms^-1) gravity
-        L_c (-> (/ fire-line-intensity ;characteristic length of plume
-                   (* ambient-gas-density
-                      specific-heat-gas
-                      temperature
-                      (Math/sqrt g)))
-                (Math/pow (/ 2 3)))]
-    (/ wind-speed-20ft
-       (Math/sqrt (* g L_c)))))
+(defn- sample-spotting-params
+  [param rand-gen]
+  (if (map? param)
+    (let [{:keys [lo hi]} param
+          l               (if (vector? lo) (my-rand-range rand-gen lo) lo)
+          h               (if (vector? hi) (my-rand-range rand-gen hi) hi)]
+      (my-rand-range rand-gen [l h]))
+    param))
 
-(defn buoyancy-driven? [froude]
-  (<= froude 1))
-
-(defn deviation-fb
-  "Returns standard deviation as described in Perryman 2013 EQ5 and EQ6 given:
-  froude number: (Int)
+(defn- mean-variance
+  "Returns mean spottind distance and it's variance given:
   fire-line-intensity: (kWm^-1)
   wind-speed-20ft: (ms^-1)"
-  [froude fire-line-intensity wind-speed-20ft]
-  (if (buoyancy-driven? froude)
-    (+ (* 0.86 (Math/pow fire-line-intensity -0.21) (Math/pow wind-speed-20ft 0.44)) 0.19)
-    (- (* 4.95 (Math/pow fire-line-intensity -0.01) (Math/pow wind-speed-20ft -0.02)) 3.48)))
+  [{:keys [mean-distance flin-exp ws-exp normalized-distance-variance]}
+   rand-gen fire-line-intensity wind-speed-20ft]
+  (let [a (sample-spotting-params mean-distance rand-gen)
+        b (sample-spotting-params flin-exp rand-gen)
+        c (sample-spotting-params ws-exp rand-gen)
+        m (* a (Math/pow fire-line-intensity b) (Math/pow wind-speed-20ft c))]
+    {:mean m :variance (* m normalized-distance-variance)}))
 
-(defn mean-fb
-  "Returns mean as described in Perryman 2013 EQ5 and EQ6 given:
-  froude number: (Int)
-  fire-line-intensity: (kWm^-1)
-  wind-speed-20ft: (ms^-1)"
-  [froude fire-line-intensity wind-speed-20ft]
-  (if (buoyancy-driven? froude)
-    (+ (* 1.47 (Math/pow fire-line-intensity 0.54) (Math/pow wind-speed-20ft -0.55)) 1.14)
-    (- (* 1.32 (Math/pow fire-line-intensity 0.26) (Math/pow wind-speed-20ft 0.11)) 0.02)))
+(defn- standard-deviation
+  "Returns standard deviation for the lognormal distribution given:
+  mean spotting distance and it's variance"
+  [m v]
+  (Math/sqrt (Math/log (+ 1 (/ v (Math/pow m 2))))))
 
-(defn- sample-num-firebrands
-  [{:keys [num-firebrands]} rand-gen]
-  (if (map? num-firebrands)
-    (let [{:keys [lo hi]} num-firebrands
-          l               (if (vector? lo) (my-rand-int-range rand-gen lo) lo)
-          h               (if (vector? hi) (my-rand-int-range rand-gen hi) hi)]
-      (my-rand-int-range rand-gen [l h]))
-    num-firebrands))
+(defn- normalized-mean
+  "Returns normalized mean for the lognormal distribution given:
+  mean spotting distance and it's variance"
+  [m v]
+  (Math/log (/ (Math/pow m 2)
+               (Math/sqrt (+ v (Math/pow m 2))))))
 
-(defn sample-wind-dir-deltas
+(defn- sample-wind-dir-deltas
   "Returns a sequence of [x y] distances (meters) that firebrands land away
   from a torched cell at i j where:
   x: parallel to the wind
-  y: perpendicular to the wind (positive values are to the right of wind direction)
-  "
-  [{:keys [spotting rand-gen random-seed] :as config}
+  y: perpendicular to the wind (positive values are to the right of wind direction)"
+  [{:keys [spotting rand-gen random-seed]}
    fire-line-intensity-matrix
-   wind-speed-20ft
-   temperature
-   [i j]]
-  (let [{:keys
-         [ambient-gas-density
-          specific-heat-gas]} spotting
-        num-firebrands        (sample-num-firebrands spotting rand-gen)
-        intensity             (convert/Btu-ft-s->kW-m (m/mget fire-line-intensity-matrix i j))
-        froude                (froude-number intensity
-                                             wind-speed-20ft
-                                             temperature
-                                             ambient-gas-density
-                                             specific-heat-gas)
-        parallel              (distribution/log-normal {:mu (mean-fb froude intensity wind-speed-20ft)
-                                                        :sd (deviation-fb froude intensity wind-speed-20ft)})
-        perpendicular         (distribution/normal {:mu 0
-                                                    :sd 0.92})]
-    (map (comp
-          (partial mapv convert/m->ft)
-          vector)
-         (distribution/sample num-firebrands parallel {:seed random-seed})
-         (distribution/sample num-firebrands perpendicular {:seed random-seed}))))
+   wind-speed-20ft [i j]]
+  (let [num-firebrands          (sample-spotting-params (:num-firebrands spotting) rand-gen)
+        intensity               (convert/Btu-ft-s->kW-m (m/mget fire-line-intensity-matrix i j))
+        {:keys [mean variance]} (mean-variance spotting rand-gen intensity wind-speed-20ft)
+        mu                      (normalized-mean mean variance)
+        sd                      (standard-deviation mean variance)
+        parallel                (distribution/log-normal {:mu mu :sd sd})
+        perpendicular           (distribution/normal {:mu 0 :sd 0.92})
+        parallel-values         (distribution/sample num-firebrands parallel {:seed random-seed})
+        perpendicular-values    (distribution/sample num-firebrands perpendicular {:seed random-seed})]
+    (map (comp (partial mapv convert/m->ft) vector)
+         parallel-values
+         perpendicular-values)))
 #+end_src
 
 Since the results are distance deltas relative to the wind direction we must
@@ -2509,7 +2483,7 @@ these deltas by using trigonometric functions.
         cell-center  (mapv #(+ step (* % step)) cell)
         coord-deltas (deltas-wind->coord deltas wind-towards-direction)]
     (map (comp
-          (partial map int)
+          (partial map long)
           (partial map #(quot % step))
           (partial map + cell-center))
          coord-deltas)))
@@ -2538,8 +2512,7 @@ firebrands landing in a cell.
 (defn specific-heat-dry-fuel
   "Returns specific heat of dry fuel given:
   initiial-temp: (Celcius)
-  ignition-temp: (Celcius)
-  "
+  ignition-temp: (Celcius)"
   [initial-temp ignition-temp]
   (+ 0.266 (* 0.0016 (/ (+ ignition-temp initial-temp) 2))))
 
@@ -2582,12 +2555,12 @@ firebrands landing in a cell.
 
 (defn spot-ignition-probability
   [{:keys [cell-size landfire-rasters]}
-   {:keys [decay-constant] :as spot-config}
+   {:keys [decay-constant]}
    temperature
    relative-humidity
    firebrand-count
    torched-origin
-   [i j :as here]]
+   here]
   (let [ignition-probability (schroeder-ign-prob relative-humidity
                                                  temperature)
         distance             (ft->m (distance-3d (:elevation landfire-rasters)
@@ -2629,11 +2602,11 @@ $t_I$ is also assumed to be 20 min as used in McAlpine and Wakimoto (1991).
         z-max          (* 0.39 D (Math/pow 10 5))
         t-steady-state 20    ;min
         t-max-height   (convert/sec->min ;min
-                            (+ (/ (* 2 flame-length) wind-speed-20ft)
-                               1.2
-                               (* (/ a 3.0)
-                                  (- (Math/pow (/ (+ b (/ z-max flame-length)) a) (/ 3.0 2.0)) 1))))]
-    (+ global-clock (* 2 t-max-height) 20)))
+                        (+ (/ (* 2 flame-length) wind-speed-20ft)
+                           1.2
+                           (* (/ a 3.0)
+                              (- (Math/pow (/ (+ b (/ z-max flame-length)) a) (/ 3.0 2.0)) 1))))]
+    (+ global-clock (* 2 t-max-height) t-steady-state)))
 #+end_src
 
 Once the locations, ignition probabilities, and time of ignition has been
@@ -2671,7 +2644,7 @@ ignition probability.
           0.0
           fuel-range-percents))
 
-(defn surface-fire-spot-fire?
+(defn- surface-fire-spot-fire?
   "Expects surface-fire-spotting config to be a sequence of tuples of
   ranges [lo hi] and spottting percent. The range represents the range (inclusive)
   of fuel model numbers that the spotting percent is set to.
@@ -2689,7 +2662,7 @@ ignition probability.
             spot-percent        (surface-spot-percent fuel-range-percents fuel-model-number)]
         (>= spot-percent (random-float 0.0 1.0 rand-gen))))))
 
-(defn crown-spot-fire? [{:keys [spotting rand-gen]}]
+(defn- crown-spot-fire? [{:keys [spotting rand-gen]}]
   (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
     (let [p (if (vector? spot-percent)
               (let [[lo hi] spot-percent]
@@ -2697,7 +2670,7 @@ ignition probability.
               spot-percent)]
       (>= p (random-float 0.0 1.0 rand-gen)))))
 
-(defn spot-fire? [config constants crown-fire? here fire-line-intensity]
+(defn- spot-fire? [config constants crown-fire? here fire-line-intensity]
   (if crown-fire?
     (crown-spot-fire? config)
     (surface-fire-spot-fire? config constants here fire-line-intensity)))
@@ -2725,7 +2698,6 @@ ignition probability.
           deltas                (sample-wind-dir-deltas config
                                                         fire-line-intensity-matrix
                                                         (convert/mph->mps wind-speed-20ft)
-                                                        (convert/F->K temperature)
                                                         cell)
           wind-to-direction     (mod (+ 180 wind-from-direction) 360)
           firebrands            (firebrands deltas wind-to-direction cell cell-size)]
@@ -3448,10 +3420,12 @@ or false:
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))
 
-(defn my-rand-int-range
+(defn my-rand-range
   [rand-generator [min-val max-val]]
   (let [range (- max-val min-val)]
-    (+ min-val (int (my-rand rand-generator range)))))
+    (+ min-val (if (and (int? min-val) (int? max-val))
+                 (int (my-rand rand-generator range))
+                 (my-rand rand-generator range)))))
 
 (defn sample-from-list
   [rand-generator n xs]
@@ -4146,9 +4120,7 @@ configuration:
     surface fire spotting does not occur
 
 #+begin_src clojure
-{:spotting {:ambient-gas-density         1.1    ;(kgm^-3)
-            :specific-heat-gas           1121.0 ;(KJkg^-1 K^-1)
-            :num-firebrands              [10 50]
+{:spotting {:num-firebrands              [10 50]
             :decay-constant              0.005
             :crown-fire-spotting-percent 0.
             :surface-fires-spotting      {:spotting-percent             [[1 100] 1.0]

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2408,7 +2408,7 @@ the direction perpendicular to the wind.
     param))
 
 (defn- mean-variance
-  "Returns mean spottind distance and it's variance given:
+  "Returns mean spotting distance and it's variance given:
   fire-line-intensity: (kWm^-1)
   wind-speed-20ft: (ms^-1)"
   [{:keys [mean-distance flin-exp ws-exp normalized-distance-variance]}
@@ -2417,7 +2417,7 @@ the direction perpendicular to the wind.
         b (sample-spotting-params flin-exp rand-gen)
         c (sample-spotting-params ws-exp rand-gen)
         m (* a (Math/pow fire-line-intensity b) (Math/pow wind-speed-20ft c))]
-    {:mean m :variance (* m normalized-distance-variance)}))
+    {:mean m :variance (* m (sample-spotting-params normalized-distance-variance rand-gen))}))
 
 (defn- standard-deviation
   "Returns standard deviation for the lognormal distribution given:
@@ -2460,10 +2460,10 @@ these deltas by using trigonometric functions.
 
 #+name: convert-deltas
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/spotting.clj :padline no :no-expand :comments link
-(defn hypotenuse [x y]
+(defn- hypotenuse [x y]
   (Math/sqrt (+ (Math/pow x 2) (Math/pow y 2))))
 
-(defn deltas-wind->coord
+(defn- deltas-wind->coord
   "Converts deltas from the torched tree in the wind direction to deltas
   in the coordinate plane"
   [deltas wind-direction]
@@ -2476,14 +2476,14 @@ these deltas by using trigonometric functions.
             (* H (Math/sin (convert/deg->rad t3)))]))
        deltas))
 
-(defn firebrands
+(defn- firebrands
   "Returns a sequence of cells that firebrands land in"
   [deltas wind-towards-direction cell cell-size]
   (let [step         (/ cell-size 2)
         cell-center  (mapv #(+ step (* % step)) cell)
         coord-deltas (deltas-wind->coord deltas wind-towards-direction)]
     (map (comp
-          (partial map long)
+          (partial map int)
           (partial map #(quot % step))
           (partial map + cell-center))
          coord-deltas)))
@@ -2509,14 +2509,14 @@ firebrands landing in a cell.
 
 #+name: firebrand-ignition-probability
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/spotting.clj :padline no :no-expand :comments link
-(defn specific-heat-dry-fuel
+(defn- specific-heat-dry-fuel
   "Returns specific heat of dry fuel given:
   initiial-temp: (Celcius)
   ignition-temp: (Celcius)"
   [initial-temp ignition-temp]
   (+ 0.266 (* 0.0016 (/ (+ ignition-temp initial-temp) 2))))
 
-(defn heat-of-preignition
+(defn- heat-of-preignition
   "Returns heat of preignition given:
   init-temperature: (Celcius)
   ignition-temperature: (Celcius)
@@ -2540,7 +2540,7 @@ firebrands landing in a cell.
         Q_d (* 540 M)]
     (+ Q_a Q_b Q_c Q_d)))
 
-(defn schroeder-ign-prob
+(defn- schroeder-ign-prob
   "Returns the probability of ignition as described in Shroeder (1969) given:
   relative-humidity: (%)
   temperature: (Farenheit)"
@@ -2553,7 +2553,7 @@ firebrands landing in a cell.
         X                    (/ (- 400 Q_ig) 10)]
     (/ (* 0.000048 (Math/pow X 4.3)) 50)))
 
-(defn spot-ignition-probability
+(defn- spot-ignition-probability
   [{:keys [cell-size landfire-rasters]}
    {:keys [decay-constant]}
    temperature
@@ -2585,12 +2585,12 @@ $t_I$ is also assumed to be 20 min as used in McAlpine and Wakimoto (1991).
 
 #+name: firebrands-time-of-ignition
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/spotting.clj :padline no :no-expand :comments link
-(defn spot-ignition?
+(defn- spot-ignition?
   [rand-gen spot-ignition-probability]
   (let [random-number (random-float 0 1 rand-gen)]
     (> spot-ignition-probability random-number)))
 
-(defn spot-ignition-time
+(defn- spot-ignition-time
   "Returns the time of spot ignition in minutes given:
   global-clock: (min)
   flame-length: (m)
@@ -2616,7 +2616,7 @@ firebrand and the value [t p] where t is the time of igintion and p is the
 ignition probability.
 #+name: spread-firebrands
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/spotting.clj :padline no :no-expand :comments link
-(defn update-firebrand-counts!
+(defn- update-firebrand-counts!
   [{:keys [num-rows num-cols landfire-rasters]}
    firebrand-count-matrix
    fire-spread-matrix
@@ -2635,7 +2635,7 @@ ignition probability.
   [[min max] fuel-model-number]
   (<= min fuel-model-number max))
 
-(defn surface-spot-percent
+(defn- surface-spot-percent
   [fuel-range-percents fuel-model-number]
   (reduce (fn [acc [fuel-range percent]]
             (if (in-range? fuel-range fuel-model-number)

--- a/src/gridfire/utils/random.clj
+++ b/src/gridfire/utils/random.clj
@@ -19,10 +19,12 @@
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))
 
-(defn my-rand-int-range
+(defn my-rand-range
   [rand-generator [min-val max-val]]
   (let [range (- max-val min-val)]
-    (+ min-val (int (my-rand rand-generator range)))))
+    (+ min-val (if (and (int? min-val) (int? max-val))
+                 (int (my-rand rand-generator range))
+                 (my-rand rand-generator range)))))
 
 (defn sample-from-list
   [rand-generator n xs]


### PR DESCRIPTION
Perryman's equations are giving us mean and standard deviations that cause the sampling of distances a firebrand can land to be order magnitudes larger than nominal values.

This PR will replace those equations with Elmfire's equations