### PR TITLE
Update elmfire_post process to output less results

### DIFF
--- a/resources/build_geoserver_directory.sh
+++ b/resources/build_geoserver_directory.sh
@@ -13,8 +13,10 @@ mkdir geoserver/$FIRENAME
 mkdir geoserver/$FIRENAME/${START_DATE}_${START_TIME}
 mkdir geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/
 mkdir geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/
-for BP in 10 20 30 40 50 60 70 80 90; do
-   mkdir ./geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/$BP
+
+for BP in 10 30 50 70 90; do
+    mkdir ./geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/$BP
+    cp ./imagemosaic/*.properties ./geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/$BP/
 done
 
 rename () {

--- a/resources/elmfire_post.sh
+++ b/resources/elmfire_post.sh
@@ -32,6 +32,11 @@ echo "NUM_TIMESTEPS = $NUM_TIMESTEPS"                 >> elmfire_post.data
 echo "POSTPROCESS_TYPE = 1"                           >> elmfire_post.data
 echo "BINARY_FILE_TYPE = 2"                           >> elmfire_post.data
 echo "FIRE_SIZE_STATS_FILENAME = 'summary_stats.csv'" >> elmfire_post.data
+echo "N_PERCENTILES = 5"                              >> elmfire_post.data
+echo "PERCENTILES(:) = 10.0, 30.0, 50.0, 70.0, 90.0"  >> elmfire_post.data
+echo "DUMP_FLAME_LENGTH = .FALSE."                    >> elmfire_post.data
+echo "DUMP_SPREAD_RATE = .FALSE."                     >> elmfire_post.data
+echo "DUMP_CROWN_FIRE = .FALSE."                      >> elmfire_post.data
 echo "/"                                              >> elmfire_post.data
 
 OMP_PROC_BIND=true $MPIRUN --mca btl tcp,self,vader --map-by core --bind-to core -np $NP -host $HOSTS $ELMFIRE_POST elmfire_post.data 1> /dev/null

--- a/resources/elmfire_post.sh
+++ b/resources/elmfire_post.sh
@@ -3,7 +3,7 @@
 rm -f *.bil *.hdr *.tif
 
 if [ -z "$ELMFIRE_VER" ]; then
-   ELMFIRE_VER=0.6548
+   ELMFIRE_VER=0.6550
 fi
 ELMFIRE_POST=elmfire_post_$ELMFIRE_VER
 MPIRUN=/usr/bin/mpirun

--- a/resources/elmfire_post.sh
+++ b/resources/elmfire_post.sh
@@ -8,7 +8,6 @@ fi
 ELMFIRE_POST=elmfire_post_$ELMFIRE_VER
 MPIRUN=/usr/bin/mpirun
 HOSTS=`printf "$(hostname),%.0s" {1..64}`
-NP=`grep processor /proc/cpuinfo | wc -l`
 CELLSIZE=`cat ../elmfire.data | grep COMPUTATIONAL_DOMAIN_CELLSIZE | cut -d= -f2 | xargs`
 XLLCORNER=`cat ../elmfire.data | grep COMPUTATIONAL_DOMAIN_XLLCORNER | cut -d= -f2 | xargs`
 YLLCORNER=`cat ../elmfire.data | grep COMPUTATIONAL_DOMAIN_YLLCORNER | cut -d= -f2 | xargs`
@@ -39,6 +38,6 @@ echo "DUMP_SPREAD_RATE = .FALSE."                     >> elmfire_post.data
 echo "DUMP_CROWN_FIRE = .FALSE."                      >> elmfire_post.data
 echo "/"                                              >> elmfire_post.data
 
-OMP_PROC_BIND=true $MPIRUN --mca btl tcp,self,vader --map-by core --bind-to core -np $NP -host $HOSTS $ELMFIRE_POST elmfire_post.data 1> /dev/null
+OMP_PROC_BIND=true $MPIRUN --mca btl tcp,self,vader --map-by core --bind-to core --use-hwthread-cpus -host $HOSTS $ELMFIRE_POST elmfire_post.data 1> /dev/null
 
 echo "Built .bil & .hdr files"


### PR DESCRIPTION
This PR:
- decreases the number of percentiles from 9 to 5
- disabled generation of spread rate, flame length, and crown fire outputs