### PR TITLE
Remove extract-constants and use sample-at

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1852,12 +1852,12 @@ pseudo-code lays out the steps taken in this procedure:
             [clojure.core.reducers         :as r]
             [gridfire.common               :refer [burnable-fuel-model?
                                                    burnable?
-                                                   extract-constants
                                                    get-fuel-moisture
                                                    fuel-moisture-from-raster
                                                    in-bounds?
                                                    burnable-neighbors?
-                                                   get-neighbors]]
+                                                   get-neighbors
+                                                   sample-at]]
             [gridfire.crown-fire          :refer [crown-fire-eccentricity
                                                   crown-fire-line-intensity
                                                   cruz-crown-fire-spread
@@ -1971,8 +1971,13 @@ pseudo-code lays out the steps taken in this procedure:
      :fire-type           (if crown-fire? crown-type :surface)
      :crown-fire?         crown-fire?}))
 
+(defn- get-value-at [here global-clock matrix-or-val multiplier perturb-info]
+  (if (> (m/dimensionality matrix-or-val) 1)
+    (sample-at here global-clock matrix-or-val multiplier perturb-info)
+    matrix-or-val))
+
 (defn compute-neighborhood-fire-spread-rates!
-   "Returns a vector of entries of the form:
+  "Returns a vector of entries of the form:
   {:cell [i j],
    :trajectory [di dj],
    :terrain-distance ft,
@@ -1980,25 +1985,69 @@ pseudo-code lays out the steps taken in this procedure:
    :fire-line-intensity Btu/ft/s,
    :flame-length ft,
    :fractional-distance [0-1]}, one for each cell adjacent to here."
-  [{:keys [landfire-rasters
-           foliar-moisture ellipse-adjustment-factor cell-size num-rows num-cols] :as constants}
+  [{:keys [landfire-rasters multiplier-lookup perturbations wind-speed-20ft wind-from-direction
+           temperature relative-humidity foliar-moisture ellipse-adjustment-factor
+           cell-size num-rows num-cols] :as constants}
    fire-spread-matrix
-   [i j :as here]
+   here
    overflow-trajectory
    overflow-heat
    global-clock]
-  (let [{:keys
-         [aspect
-          canopy-base-height
-          canopy-cover
-          canopy-height
-          crown-bulk-density
-          fuel-model
-          relative-humidity
-          slope
-          temperature
-          wind-from-direction
-          wind-speed-20ft]}           (extract-constants constants global-clock here)
+  (let [aspect                      (sample-at here
+                                               global-clock
+                                               (:aspect landfire-rasters)
+                                               (:aspect multiplier-lookup)
+                                               (:aspect perturbations))
+        canopy-base-height          (sample-at here
+                                               global-clock
+                                               (:canopy-base-height landfire-rasters)
+                                               (:canopy-base-height multiplier-lookup)
+                                               (:canopy-base-height perturbations))
+        canopy-cover                (sample-at here
+                                               global-clock
+                                               (:canopy-cover landfire-rasters)
+                                               (:canopy-cover multiplier-lookup)
+                                               (:canopy-cover perturbations))
+        canopy-height               (sample-at here
+                                               global-clock
+                                               (:canopy-height landfire-rasters)
+                                               (:canopy-height multiplier-lookup)
+                                               (:canopy-height perturbations))
+        crown-bulk-density           (sample-at here
+                                                global-clock
+                                                (:crown-bulk-density landfire-rasters)
+                                                (:crown-bulk-density multiplier-lookup)
+                                                (:crown-bulk-density perturbations))
+        fuel-model                   (sample-at here
+                                                global-clock
+                                                (:fuel-model landfire-rasters)
+                                                (:fuel-model multiplier-lookup)
+                                                (:fuel-model perturbations))
+        slope                        (sample-at here
+                                                global-clock
+                                                (:slope landfire-rasters)
+                                                (:slope multiplier-lookup)
+                                                (:slope perturbations))
+        relative-humidity            (get-value-at here
+                                                   global-clock
+                                                   relative-humidity
+                                                   (:relative-humidity multiplier-lookup)
+                                                   (:relative-humidity perturbations))
+        temperature                   (get-value-at here
+                                                    global-clock
+                                                    temperature
+                                                    (:temperature multiplier-lookup)
+                                                    (:temperature perturbations))
+        wind-from-direction           (get-value-at here
+                                                    global-clock
+                                                    wind-from-direction
+                                                    (:wind-from-direction multiplier-lookup)
+                                                    (:wind-from-direction perturbations))
+        wind-speed-20ft               (get-value-at here
+                                                    global-clock
+                                                    wind-speed-20ft
+                                                    (:wind-speed-20ft multiplier-lookup)
+                                                    (:wind-speed-20ft perturbations))
         fuel-moisture                 (or (fuel-moisture-from-raster constants here global-clock)
                                           (get-fuel-moisture relative-humidity temperature))
         [fuel-model spread-info-min]  (rothermel-fast-wrapper fuel-model fuel-moisture)
@@ -2083,18 +2132,16 @@ pseudo-code lays out the steps taken in this procedure:
 (defn generate-ignited-cells
   [constants fire-spread-matrix cells]
   (when (seq cells)
-    (persistent!
-     (reduce (fn [ignited-cells cell]
-               (apply conj
-                      ignited-cells
-                      (compute-neighborhood-fire-spread-rates! constants
-                                                               fire-spread-matrix
-                                                               cell
-                                                               nil
-                                                               0.0
-                                                               0.0)))
-             (transient [])
-             cells))))
+    (reduce (fn [ignited-cells cell]
+              (into ignited-cells
+                    (compute-neighborhood-fire-spread-rates! constants
+                                                             fire-spread-matrix
+                                                             cell
+                                                             nil
+                                                             0.0
+                                                             0.0)))
+            []
+            cells)))
 
 (defn identify-spot-ignition-events
   [global-clock spot-ignitions]

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1872,7 +1872,8 @@ pseudo-code lays out the steps taken in this procedure:
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]))
+                                                  wind-adjustment-factor]]
+            [taoensso.tufte :as tufte]))
 
 (m/set-current-implementation :vectorz)
 
@@ -2217,8 +2218,8 @@ pseudo-code lays out the steps taken in this procedure:
     (if (and (< global-clock max-runtime)
              (seq ignited-cells))
       (let [dt                (->> ignited-cells
-                                   (reduce (fn [max-spread-rate {:keys [spread-rate]}]
-                                             (max max-spread-rate spread-rate))
+                                   (reduce (fn [max-spread-rate ignited-cell]
+                                             (max max-spread-rate (:spread-rate ignited-cell)))
                                            0.0)
                                    (/ cell-size))
             timestep          (if (> (+ global-clock dt) max-runtime)

--- a/src/gridfire/common.clj
+++ b/src/gridfire/common.clj
@@ -24,6 +24,11 @@
          (+ value-here (perturbation/value-at perturb-info matrix cell)))
        value-here))))
 
+(defn get-value-at [here global-clock matrix-or-val multiplier perturb-info]
+  (if (> (m/dimensionality matrix-or-val) 1)
+    (sample-at here global-clock matrix-or-val multiplier perturb-info)
+    matrix-or-val))
+
 (defn calc-emc
   "Computes the Equilibrium Moisture Content (EMC) from rh (relative
    humidity in %) and temp (temperature in F)."

--- a/src/gridfire/common.clj
+++ b/src/gridfire/common.clj
@@ -15,7 +15,7 @@
 
   ([here global-clock matrix multiplier perturb-info]
    (let [cell       (if multiplier
-                      (map #(quot % multiplier) here)
+                      (mapv #(quot % multiplier) here)
                       here)
          value-here (matrix-value-at cell global-clock matrix)]
      (if perturb-info
@@ -23,30 +23,6 @@
          (+ value-here (perturbation/value-at perturb-info matrix cell (quot global-clock freq)))
          (+ value-here (perturbation/value-at perturb-info matrix cell)))
        value-here))))
-
-(defn extract-constants
-
-  [{:keys [landfire-rasters wind-speed-20ft wind-from-direction temperature
-           relative-humidity foliar-moisture ellipse-adjustment-factor
-           multiplier-lookup perturbations]}
-   global-clock
-   [i j :as here]]
-  (let [layers (merge landfire-rasters
-                      {:wind-speed-20ft     wind-speed-20ft
-                       :wind-from-direction wind-from-direction
-                       :temperature         temperature
-                       :relative-humidity   relative-humidity})]
-    (reduce-kv
-     (fn[acc name val]
-       (if (> (m/dimensionality val) 1)
-         (assoc acc name (sample-at here
-                                    global-clock
-                                    val
-                                    (name multiplier-lookup)
-                                    (name perturbations)))
-         (assoc acc name val)))
-     {}
-     layers)))
 
 (defn calc-emc
   "Computes the Equilibrium Moisture Content (EMC) from rh (relative

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -10,6 +10,7 @@
                                                    in-bounds?
                                                    burnable-neighbors?
                                                    get-neighbors
+                                                   get-value-at
                                                    sample-at]]
             [gridfire.crown-fire          :refer [crown-fire-eccentricity
                                                   crown-fire-line-intensity
@@ -124,11 +125,6 @@
                                        0.0))
      :fire-type           (if crown-fire? crown-type :surface)
      :crown-fire?         crown-fire?}))
-
-(defn- get-value-at [here global-clock matrix-or-val multiplier perturb-info]
-  (if (> (m/dimensionality matrix-or-val) 1)
-    (sample-at here global-clock matrix-or-val multiplier perturb-info)
-    matrix-or-val))
 
 (defn compute-neighborhood-fire-spread-rates!
   "Returns a vector of entries of the form:

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -5,12 +5,12 @@
             [clojure.core.reducers         :as r]
             [gridfire.common               :refer [burnable-fuel-model?
                                                    burnable?
-                                                   extract-constants
                                                    get-fuel-moisture
                                                    fuel-moisture-from-raster
                                                    in-bounds?
                                                    burnable-neighbors?
-                                                   get-neighbors]]
+                                                   get-neighbors
+                                                   sample-at]]
             [gridfire.crown-fire          :refer [crown-fire-eccentricity
                                                   crown-fire-line-intensity
                                                   cruz-crown-fire-spread
@@ -124,8 +124,13 @@
      :fire-type           (if crown-fire? crown-type :surface)
      :crown-fire?         crown-fire?}))
 
+(defn- get-value-at [here global-clock matrix-or-val multiplier perturb-info]
+  (if (> (m/dimensionality matrix-or-val) 1)
+    (sample-at here global-clock matrix-or-val multiplier perturb-info)
+    matrix-or-val))
+
 (defn compute-neighborhood-fire-spread-rates!
-   "Returns a vector of entries of the form:
+  "Returns a vector of entries of the form:
   {:cell [i j],
    :trajectory [di dj],
    :terrain-distance ft,
@@ -133,25 +138,69 @@
    :fire-line-intensity Btu/ft/s,
    :flame-length ft,
    :fractional-distance [0-1]}, one for each cell adjacent to here."
-  [{:keys [landfire-rasters
-           foliar-moisture ellipse-adjustment-factor cell-size num-rows num-cols] :as constants}
+  [{:keys [landfire-rasters multiplier-lookup perturbations wind-speed-20ft wind-from-direction
+           temperature relative-humidity foliar-moisture ellipse-adjustment-factor
+           cell-size num-rows num-cols] :as constants}
    fire-spread-matrix
-   [i j :as here]
+   here
    overflow-trajectory
    overflow-heat
    global-clock]
-  (let [{:keys
-         [aspect
-          canopy-base-height
-          canopy-cover
-          canopy-height
-          crown-bulk-density
-          fuel-model
-          relative-humidity
-          slope
-          temperature
-          wind-from-direction
-          wind-speed-20ft]}           (extract-constants constants global-clock here)
+  (let [aspect                      (sample-at here
+                                               global-clock
+                                               (:aspect landfire-rasters)
+                                               (:aspect multiplier-lookup)
+                                               (:aspect perturbations))
+        canopy-base-height          (sample-at here
+                                               global-clock
+                                               (:canopy-base-height landfire-rasters)
+                                               (:canopy-base-height multiplier-lookup)
+                                               (:canopy-base-height perturbations))
+        canopy-cover                (sample-at here
+                                               global-clock
+                                               (:canopy-cover landfire-rasters)
+                                               (:canopy-cover multiplier-lookup)
+                                               (:canopy-cover perturbations))
+        canopy-height               (sample-at here
+                                               global-clock
+                                               (:canopy-height landfire-rasters)
+                                               (:canopy-height multiplier-lookup)
+                                               (:canopy-height perturbations))
+        crown-bulk-density           (sample-at here
+                                                global-clock
+                                                (:crown-bulk-density landfire-rasters)
+                                                (:crown-bulk-density multiplier-lookup)
+                                                (:crown-bulk-density perturbations))
+        fuel-model                   (sample-at here
+                                                global-clock
+                                                (:fuel-model landfire-rasters)
+                                                (:fuel-model multiplier-lookup)
+                                                (:fuel-model perturbations))
+        slope                        (sample-at here
+                                                global-clock
+                                                (:slope landfire-rasters)
+                                                (:slope multiplier-lookup)
+                                                (:slope perturbations))
+        relative-humidity            (get-value-at here
+                                                   global-clock
+                                                   relative-humidity
+                                                   (:relative-humidity multiplier-lookup)
+                                                   (:relative-humidity perturbations))
+        temperature                   (get-value-at here
+                                                    global-clock
+                                                    temperature
+                                                    (:temperature multiplier-lookup)
+                                                    (:temperature perturbations))
+        wind-from-direction           (get-value-at here
+                                                    global-clock
+                                                    wind-from-direction
+                                                    (:wind-from-direction multiplier-lookup)
+                                                    (:wind-from-direction perturbations))
+        wind-speed-20ft               (get-value-at here
+                                                    global-clock
+                                                    wind-speed-20ft
+                                                    (:wind-speed-20ft multiplier-lookup)
+                                                    (:wind-speed-20ft perturbations))
         fuel-moisture                 (or (fuel-moisture-from-raster constants here global-clock)
                                           (get-fuel-moisture relative-humidity temperature))
         [fuel-model spread-info-min]  (rothermel-fast-wrapper fuel-model fuel-moisture)

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -25,7 +25,8 @@
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]))
+                                                  wind-adjustment-factor]]
+            [taoensso.tufte :as tufte]))
 
 (m/set-current-implementation :vectorz)
 
@@ -370,8 +371,8 @@
     (if (and (< global-clock max-runtime)
              (seq ignited-cells))
       (let [dt                (->> ignited-cells
-                                   (reduce (fn [max-spread-rate {:keys [spread-rate]}]
-                                             (max max-spread-rate spread-rate))
+                                   (reduce (fn [max-spread-rate ignited-cell]
+                                             (max max-spread-rate (:spread-rate ignited-cell)))
                                            0.0)
                                    (/ cell-size))
             timestep          (if (> (+ global-clock dt) max-runtime)


### PR DESCRIPTION
Findings: Extract-constants is uncessarily building up a map just to destructure.
Optimization: Instead call sample-at directly in compute-neighborhood-spread-rates 

Optimized Run:
pId                  nCalls        Min        Max       Mean   MAD      Clock  Total

:run-fire-spread         10     4.01ms     4.52s      1.96s   ±99%    19.61s     96%

Accounted                                                             19.61s     96%
Clock                                                                 20.47s    100%

vs

Not Optimized Run:
04/22 10:26:32 Running simulations
04/22 10:26:56 :run-simulation,
pId                  nCalls        Min        Max       Mean   MAD      Clock  Total

:run-fire-spread         10     4.28ms     5.12s      2.24s   ±99%    22.39s     96%

Accounted                                                             22.39s     96%
Clock                                                                 23.24s    100%

There's a micro improvement of 15%