### PR TITLE
GRID-146 add type hints crown-fire ns

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1481,16 +1481,16 @@ crown fire initiation occurs.
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/crown_fire.clj :padline no :no-expand :comments link
 (ns gridfire.crown-fire)
 
-(defn ft->m [ft] (* 0.3048 ft))
+(defn ft->m ^double [^double ft] (* 0.3048 ft))
 
-(defn kW-m->Btu-ft-s [kW-m] (* 0.288894658272 kW-m))
+(defn kW-m->Btu-ft-s ^double [^double kW-m] (* 0.288894658272 kW-m))
 
 (defn van-wagner-crown-fire-initiation?
   "- canopy-cover (0-100 %)
    - canopy-base-height (ft)
    - foliar-moisture (lb moisture/lb ovendry weight)
    - fire-line-intensity (Btu/ft*s)"
-  [canopy-cover canopy-base-height foliar-moisture fire-line-intensity]
+  [^double canopy-cover ^double canopy-base-height ^double foliar-moisture ^double fire-line-intensity]
   (and (> canopy-cover 40.0)
        (-> (+ 460.0 (* 2600.0 foliar-moisture)) ;; heat-of-ignition = kJ/kg
            (* 0.01 (ft->m canopy-base-height))
@@ -1520,18 +1520,18 @@ active, otherwise passive.
 
 #+name: cruz-crown-fire-spread
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/crown_fire.clj :no-expand :comments link
-(defn mph->km-hr [mph] (* 1.609344 mph))
+(defn mph->km-hr ^double [^double mph] (* 1.609344 mph))
 
-(defn lb-ft3->kg-m3 [lb-ft3] (* 16.01846 lb-ft3))
+(defn lb-ft3->kg-m3 ^double [^double lb-ft3] (* 16.01846 lb-ft3))
 
-(defn m->ft [m] (* 3.281 m))
+(defn m->ft ^double [^double m] (* 3.281 m))
 
 (defn cruz-crown-fire-spread
   "Returns spread-rate in ft/min given:
    - wind-speed-20ft (mph)
    - crown-bulk-density (lb/ft^3)
    - estimated-fine-fuel-moisture (-> M_f :dead :1hr) (0-1)"
-  [wind-speed-20ft crown-bulk-density estimated-fine-fuel-moisture]
+  [wind-speed-20ft ^double crown-bulk-density ^double estimated-fine-fuel-moisture]
   (let [wind-speed-10m               (/ (mph->km-hr wind-speed-20ft) 0.87) ;; km/hr
         crown-bulk-density           (lb-ft3->kg-m3 crown-bulk-density) ;; kg/m^3
         estimated-fine-fuel-moisture (* 100.0 estimated-fine-fuel-moisture)
@@ -1539,7 +1539,7 @@ active, otherwise passive.
                                         (Math/pow wind-speed-10m 0.90)
                                         (Math/pow crown-bulk-density 0.19)
                                         (Math/exp (* -0.17 estimated-fine-fuel-moisture)))
-                                        ;; m/min
+        ;; m/min
         critical-spread-rate         (/ 3.0 crown-bulk-density) ;; m/min
         criteria-for-active-crowning (/ active-spread-rate critical-spread-rate)]
     (if (> active-spread-rate critical-spread-rate)
@@ -1570,21 +1570,21 @@ surface fire line intensity in Btu/ft/s.
 (defn crown-fire-line-intensity
   "(ft/min * lb/ft^3 * ft * Btu/lb)/60 = (Btu/ft*min)/60 = Btu/ft*s"
   [crown-spread-rate crown-bulk-density canopy-height canopy-base-height heat-of-combustion]
-  (/ (* crown-spread-rate
-        crown-bulk-density
-        (- canopy-height canopy-base-height)
-        heat-of-combustion)
+  (/ (* ^double crown-spread-rate
+        ^double crown-bulk-density
+        (- ^double canopy-height ^double canopy-base-height)
+        ^double heat-of-combustion)
      60.0))
 
 (defn crown-fire-line-intensity-elmfire ;; kW/m
   [surface-fire-line-intensity crown-spread-rate crown-bulk-density
    canopy-height canopy-base-height]
   (let [heat-of-combustion 18000] ;; kJ/m^2
-    (+ surface-fire-line-intensity ;; kW/m
+    (+ ^double surface-fire-line-intensity ;; kW/m
        (/ (* 0.3048 ;; m/ft
-             crown-spread-rate ;; ft/min
-             crown-bulk-density ;; kg/m^3
-             (- canopy-height canopy-base-height) ;; m
+             ^double crown-spread-rate ;; ft/min
+             ^double crown-bulk-density ;; kg/m^3
+             (- ^double canopy-height ^double canopy-base-height) ;; m
              heat-of-combustion) ;; kJ/kg
           60.0)))) ;; s/min
 #+end_src
@@ -1615,7 +1615,8 @@ elliptical or circular respectively.\citep{Peterson2009}
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/crown_fire.clj :no-expand :comments link
 (defn crown-fire-eccentricity
   "mph"
-  [wind-speed-20ft ellipse-adjustment-factor]
+  ^double
+  [^double wind-speed-20ft ^double ellipse-adjustment-factor]
   (let [length-width-ratio (+ 1.0 (* 0.125
                                      wind-speed-20ft
                                      ellipse-adjustment-factor))]
@@ -1626,7 +1627,8 @@ elliptical or circular respectively.\citep{Peterson2009}
   "true/false mph int>0 ft/min
    Crown L/W = min(1.0 + 0.125*U20_mph, L/W_max)
    Surface L/W = 0.936*e^(0.2566*Ueff_mph) + 0.461*e^(-0.1548*Ueff_mph) - 0.397"
-  [crown-fire? wind-speed-20ft max-length-to-width-ratio effective-wind-speed]
+  ^double
+  [crown-fire? ^double wind-speed-20ft ^double max-length-to-width-ratio ^double effective-wind-speed]
   (if crown-fire?
     (min (+ 1.0 (* 0.125 wind-speed-20ft)) max-length-to-width-ratio)
     (min (+ (* 0.936 (Math/exp (/ (* 0.2566 effective-wind-speed 60.0) 5280.0)))

--- a/src/gridfire/crown_fire.clj
+++ b/src/gridfire/crown_fire.clj
@@ -1,16 +1,16 @@
 ;; [[file:../../org/GridFire.org::van-wagner-crown-fire-initiation][van-wagner-crown-fire-initiation]]
 (ns gridfire.crown-fire)
 
-(defn ft->m [ft] (* 0.3048 ft))
+(defn ft->m ^double [^double ft] (* 0.3048 ft))
 
-(defn kW-m->Btu-ft-s [kW-m] (* 0.288894658272 kW-m))
+(defn kW-m->Btu-ft-s ^double [^double kW-m] (* 0.288894658272 kW-m))
 
 (defn van-wagner-crown-fire-initiation?
   "- canopy-cover (0-100 %)
    - canopy-base-height (ft)
    - foliar-moisture (lb moisture/lb ovendry weight)
    - fire-line-intensity (Btu/ft*s)"
-  [canopy-cover canopy-base-height foliar-moisture fire-line-intensity]
+  [^double canopy-cover ^double canopy-base-height ^double foliar-moisture ^double fire-line-intensity]
   (and (> canopy-cover 40.0)
        (-> (+ 460.0 (* 2600.0 foliar-moisture)) ;; heat-of-ignition = kJ/kg
            (* 0.01 (ft->m canopy-base-height))
@@ -20,18 +20,18 @@
 ;; van-wagner-crown-fire-initiation ends here
 
 ;; [[file:../../org/GridFire.org::cruz-crown-fire-spread][cruz-crown-fire-spread]]
-(defn mph->km-hr [mph] (* 1.609344 mph))
+(defn mph->km-hr ^double [^double mph] (* 1.609344 mph))
 
-(defn lb-ft3->kg-m3 [lb-ft3] (* 16.01846 lb-ft3))
+(defn lb-ft3->kg-m3 ^double [^double lb-ft3] (* 16.01846 lb-ft3))
 
-(defn m->ft [m] (* 3.281 m))
+(defn m->ft ^double [^double m] (* 3.281 m))
 
 (defn cruz-crown-fire-spread
   "Returns spread-rate in ft/min given:
    - wind-speed-20ft (mph)
    - crown-bulk-density (lb/ft^3)
    - estimated-fine-fuel-moisture (-> M_f :dead :1hr) (0-1)"
-  [wind-speed-20ft crown-bulk-density estimated-fine-fuel-moisture]
+  [wind-speed-20ft ^double crown-bulk-density ^double estimated-fine-fuel-moisture]
   (let [wind-speed-10m               (/ (mph->km-hr wind-speed-20ft) 0.87) ;; km/hr
         crown-bulk-density           (lb-ft3->kg-m3 crown-bulk-density) ;; kg/m^3
         estimated-fine-fuel-moisture (* 100.0 estimated-fine-fuel-moisture)
@@ -39,7 +39,7 @@
                                         (Math/pow wind-speed-10m 0.90)
                                         (Math/pow crown-bulk-density 0.19)
                                         (Math/exp (* -0.17 estimated-fine-fuel-moisture)))
-                                        ;; m/min
+        ;; m/min
         critical-spread-rate         (/ 3.0 crown-bulk-density) ;; m/min
         criteria-for-active-crowning (/ active-spread-rate critical-spread-rate)]
     (if (> active-spread-rate critical-spread-rate)
@@ -52,21 +52,21 @@
 (defn crown-fire-line-intensity
   "(ft/min * lb/ft^3 * ft * Btu/lb)/60 = (Btu/ft*min)/60 = Btu/ft*s"
   [crown-spread-rate crown-bulk-density canopy-height canopy-base-height heat-of-combustion]
-  (/ (* crown-spread-rate
-        crown-bulk-density
-        (- canopy-height canopy-base-height)
-        heat-of-combustion)
+  (/ (* ^double crown-spread-rate
+        ^double crown-bulk-density
+        (- ^double canopy-height ^double canopy-base-height)
+        ^double heat-of-combustion)
      60.0))
 
 (defn crown-fire-line-intensity-elmfire ;; kW/m
   [surface-fire-line-intensity crown-spread-rate crown-bulk-density
    canopy-height canopy-base-height]
   (let [heat-of-combustion 18000] ;; kJ/m^2
-    (+ surface-fire-line-intensity ;; kW/m
+    (+ ^double surface-fire-line-intensity ;; kW/m
        (/ (* 0.3048 ;; m/ft
-             crown-spread-rate ;; ft/min
-             crown-bulk-density ;; kg/m^3
-             (- canopy-height canopy-base-height) ;; m
+             ^double crown-spread-rate ;; ft/min
+             ^double crown-bulk-density ;; kg/m^3
+             (- ^double canopy-height ^double canopy-base-height) ;; m
              heat-of-combustion) ;; kJ/kg
           60.0)))) ;; s/min
 ;; crown-fire-line-intensity ends here
@@ -74,7 +74,8 @@
 ;; [[file:../../org/GridFire.org::crown-eccentricity][crown-eccentricity]]
 (defn crown-fire-eccentricity
   "mph"
-  [wind-speed-20ft ellipse-adjustment-factor]
+  ^double
+  [^double wind-speed-20ft ^double ellipse-adjustment-factor]
   (let [length-width-ratio (+ 1.0 (* 0.125
                                      wind-speed-20ft
                                      ellipse-adjustment-factor))]
@@ -85,7 +86,8 @@
   "true/false mph int>0 ft/min
    Crown L/W = min(1.0 + 0.125*U20_mph, L/W_max)
    Surface L/W = 0.936*e^(0.2566*Ueff_mph) + 0.461*e^(-0.1548*Ueff_mph) - 0.397"
-  [crown-fire? wind-speed-20ft max-length-to-width-ratio effective-wind-speed]
+  ^double
+  [crown-fire? ^double wind-speed-20ft ^double max-length-to-width-ratio ^double effective-wind-speed]
   (if crown-fire?
     (min (+ 1.0 (* 0.125 wind-speed-20ft)) max-length-to-width-ratio)
     (min (+ (* 0.936 (Math/exp (/ (* 0.2566 effective-wind-speed 60.0) 5280.0)))


### PR DESCRIPTION
## Purpose

Adding primitive type hints and casting to improve arithmetic performance.

## Related Issues
Closes GRID-146

## Submission Checklist
- [x] Code passes linter

## Testing
ns to test:
- `gridfire.crown-fire`

To test:
1. Start repl
2. `(set! *unchecked-math* :warn-on-boxed)`
3. send buffer to the repl (should not have warnings)