### PR TITLE
GRID-146 add type hints spotting ns

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2500,9 +2500,9 @@ the direction perpendicular to the wind.
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/spotting.clj :padline no :no-expand :comments link
 (ns gridfire.spotting
   (:require [clojure.core.matrix :as m]
-            [gridfire.common :refer [extract-constants
-                                     distance-3d
+            [gridfire.common :refer [distance-3d
                                      get-fuel-moisture
+                                     get-value-at
                                      in-bounds?
                                      burnable?
                                      fuel-moisture-from-raster]]
@@ -2516,6 +2516,7 @@ the direction perpendicular to the wind.
 ;;-----------------------------------------------------------------------------
 
 (defn- sample-spotting-params
+  ^double
   [param rand-gen]
   (if (map? param)
     (let [{:keys [lo hi]} param
@@ -2528,8 +2529,8 @@ the direction perpendicular to the wind.
   "Returns mean spotting distance and it's variance given:
   fire-line-intensity: (kWm^-1)
   wind-speed-20ft: (ms^-1)"
-  [{:keys [mean-distance flin-exp ws-exp normalized-distance-variance]}
-   rand-gen fire-line-intensity wind-speed-20ft]
+  [{:keys [^double mean-distance ^double flin-exp ^double ws-exp ^double normalized-distance-variance]}
+   rand-gen ^double fire-line-intensity ^double wind-speed-20ft]
   (let [a (sample-spotting-params mean-distance rand-gen)
         b (sample-spotting-params flin-exp rand-gen)
         c (sample-spotting-params ws-exp rand-gen)
@@ -2539,13 +2540,15 @@ the direction perpendicular to the wind.
 (defn- standard-deviation
   "Returns standard deviation for the lognormal distribution given:
   mean spotting distance and it's variance"
-  [m v]
+  ^double
+  [^double m ^double v]
   (Math/sqrt (Math/log (+ 1 (/ v (Math/pow m 2))))))
 
 (defn- normalized-mean
   "Returns normalized mean for the lognormal distribution given:
   mean spotting distance and it's variance"
-  [m v]
+  ^double
+  [^double m ^double v]
   (Math/log (/ (Math/pow m 2)
                (Math/sqrt (+ v (Math/pow m 2))))))
 
@@ -2567,8 +2570,8 @@ the direction perpendicular to the wind.
         parallel-values         (distribution/sample num-firebrands parallel {:seed random-seed})
         perpendicular-values    (distribution/sample num-firebrands perpendicular {:seed random-seed})]
     (mapv (fn [x y] [(convert/m->ft x) (convert/m->ft y)])
-         parallel-values
-         perpendicular-values)))
+          parallel-values
+          perpendicular-values)))
 #+end_src
 
 Since the results are distance deltas relative to the wind direction we must
@@ -2577,30 +2580,38 @@ these deltas by using trigonometric functions.
 
 #+name: convert-deltas
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/spotting.clj :padline no :no-expand :comments link
-(defn- hypotenuse [x y]
+(defn- hypotenuse ^double
+  [x y]
   (Math/sqrt (+ (Math/pow x 2) (Math/pow y 2))))
 
 (defn- deltas-wind->coord
   "Converts deltas from the torched tree in the wind direction to deltas
   in the coordinate plane"
-  [deltas wind-direction]
+  [deltas ^double wind-direction]
   (mapv (fn [[d-paral d-perp]]
-         (let [H  (hypotenuse d-paral d-perp)
-               t1 wind-direction
-               t2 (convert/rad->deg (Math/atan (/ d-perp d-paral)))
-               t3 (+ t1 t2)]
-           [(* -1 H (Math/cos (convert/deg->rad t3)))
-            (* H (Math/sin (convert/deg->rad t3)))]))
-       deltas))
+          (let [d-paral (double d-paral)
+                d-perp  (double d-perp)
+                H  (hypotenuse d-paral d-perp)
+                t1 wind-direction
+                t2 (convert/rad->deg (Math/atan (/ d-perp d-paral)))
+                t3 (+ t1 t2)]
+            [(* -1 H (Math/cos (convert/deg->rad t3)))
+             (* H (Math/sin (convert/deg->rad t3)))]))
+        deltas))
 
 (defn- firebrands
   "Returns a sequence of cells that firebrands land in"
-  [deltas wind-towards-direction cell cell-size]
+  [deltas wind-towards-direction cell ^double cell-size]
   (let [step         (/ cell-size 2)
-        [x y]        (mapv #(+ step (* % step)) cell)
+        [x y]        (mapv #(+ step (* ^double % step)) cell)
+        x            (double x)
+        y            (double y)
         coord-deltas (deltas-wind->coord deltas wind-towards-direction)]
-    (mapv (fn [[dx dy]] [(int (Math/floor (/ (+ dx x) step)))
-                         (int (Math/floor (/ (+ dy y) step)))])
+    (mapv (fn [[dx dy]]
+            (let [dx (double dx)
+                  dy (double dy)]
+              [(int (Math/floor (/ (+ dx x) step)))
+               (int (Math/floor (/ (+ dy y) step)))]))
           coord-deltas)))
 #+end_src
 
@@ -2628,7 +2639,8 @@ firebrands landing in a cell.
   "Returns specific heat of dry fuel given:
   initiial-temp: (Celcius)
   ignition-temp: (Celcius)"
-  [initial-temp ignition-temp]
+  ^double
+  [^double initial-temp ^double ignition-temp]
   (+ 0.266 (* 0.0016 (/ (+ ignition-temp initial-temp) 2))))
 
 (defn- heat-of-preignition
@@ -2636,7 +2648,8 @@ firebrands landing in a cell.
   init-temperature: (Celcius)
   ignition-temperature: (Celcius)
   moisture content: (Percent)"
-  [init-temperature ignition-temperature moisture]
+  ^double
+  [^double init-temperature ^double ignition-temperature ^double moisture]
   (let [T_o init-temperature
         T_i ignition-temperature
         M   moisture
@@ -2659,6 +2672,7 @@ firebrands landing in a cell.
   "Returns the probability of ignition as described in Shroeder (1969) given:
   relative-humidity: (%)
   temperature: (Farenheit)"
+  ^double
   [fuel-moisture temperature]
   (let [ignition-temperature 320 ;;FIXME should this be a constant?
         moisture             (-> fuel-moisture :dead :1hr)
@@ -2679,7 +2693,7 @@ firebrands landing in a cell.
                                                  cell-size
                                                  here
                                                  torched-origin))
-        decay-factor         (Math/exp (* -1 decay-constant distance))]
+        decay-factor         (Math/exp (* -1 ^double decay-constant distance))]
     (- 1 (Math/pow (- 1 (* ignition-probability decay-factor)) firebrand-count))))
 #+end_src
 
@@ -2698,7 +2712,7 @@ $t_I$ is also assumed to be 20 min as used in McAlpine and Wakimoto (1991).
 #+name: firebrands-time-of-ignition
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/spotting.clj :padline no :no-expand :comments link
 (defn- spot-ignition?
-  [rand-gen spot-ignition-probability]
+  [rand-gen ^double spot-ignition-probability]
   (let [random-number (random-float 0 1 rand-gen)]
     (> spot-ignition-probability random-number)))
 
@@ -2707,13 +2721,13 @@ $t_I$ is also assumed to be 20 min as used in McAlpine and Wakimoto (1991).
   global-clock: (min)
   flame-length: (m)
   wind-speed-20ft: (ms^-1)"
-  [global-clock flame-length wind-speed-20ft]
+  [^double global-clock ^double flame-length ^double wind-speed-20ft]
   (let [a              5.963
         b              (- a 1.4)
         D              0.003 ;firebrand diameter (m)
         z-max          (* 0.39 D (Math/pow 10 5))
-        t-steady-state 20 ;period of building up to steady state from ignition (min)
-        t_o            1 ;period of steady burning of tree crowns (min)
+        t-steady-state 20    ;period of building up to steady state from ignition (min)
+        t_o            1     ;period of steady burning of tree crowns (min)
         t-max-height   (+ (/ t_o (/ (* 2 flame-length) wind-speed-20ft))
                           1.2
                           (* (/ a 3.0)
@@ -2740,7 +2754,7 @@ ignition probability.
                                          (:fuel-model landfire-rasters)
                                          source
                                          here))
-          :let           [new-count (inc (m/mget firebrand-count-matrix x y))]]
+          :let           [new-count (inc ^double (m/mget firebrand-count-matrix x y))]]
     (m/mset! firebrand-count-matrix x y new-count)))
 
 (defn- in-range?
@@ -2748,6 +2762,7 @@ ignition probability.
   (<= min fuel-model-number max))
 
 (defn- surface-spot-percent
+  ^double
   [fuel-range-percents fuel-model-number rand-gen]
   (reduce (fn [acc [fuel-range percent]]
             (if (in-range? fuel-range fuel-model-number)
@@ -2765,11 +2780,11 @@ ignition probability.
   [[[1 140] 0.0]
   [[141 149] 1.0]
   [[150 256] 1.0]]"
-  [{:keys [spotting rand-gen landfire-rasters]} [i j] fire-line-intensity]
+  [{:keys [spotting rand-gen landfire-rasters]} [i j] ^double fire-line-intensity]
   (let [{:keys [surface-fire-spotting]} spotting]
     (when (and
            surface-fire-spotting
-           (> fire-line-intensity (:critical-fire-line-intensity surface-fire-spotting)))
+           (> fire-line-intensity ^double (:critical-fire-line-intensity surface-fire-spotting)))
       (let [fuel-range-percents (:spotting-percent surface-fire-spotting)
             fuel-model-raster   (:fuel-model landfire-rasters)
             fuel-model-number   (int (m/mget fuel-model-raster i j))
@@ -2778,10 +2793,10 @@ ignition probability.
 
 (defn- crown-spot-fire? [{:keys [spotting rand-gen]}]
   (when-let [spot-percent (:crown-fire-spotting-percent spotting)]
-    (let [p (if (vector? spot-percent)
-              (let [[lo hi] spot-percent]
-                (random-float lo hi rand-gen))
-              spot-percent)]
+    (let [^double p (if (vector? spot-percent)
+                      (let [[lo hi] spot-percent]
+                        (random-float lo hi rand-gen))
+                      spot-percent)]
       (>= p (random-float 0.0 1.0 rand-gen)))))
 
 (defn- spot-fire? [inputs crown-fire? here fire-line-intensity]
@@ -2795,23 +2810,42 @@ ignition probability.
   val: [t p] where:
   t: time of ignition
   p: ignition-probability"
-  [{:keys [num-rows num-cols cell-size landfire-rasters global-clock spotting rand-gen] :as inputs}
+  [{:keys
+    [num-rows num-cols cell-size landfire-rasters global-clock spotting rand-gen
+     multiplier-lookup perturbations temperature relative-humidity wind-speed-20ft
+     wind-from-direction] :as inputs}
    {:keys [firebrand-count-matrix fire-spread-matrix fire-line-intensity-matrix flame-length-matrix]}
    {:keys [cell fire-line-intensity crown-fire?]}]
   (when (spot-fire? inputs crown-fire? cell fire-line-intensity)
-    (let [{:keys
-           [wind-speed-20ft
-            temperature
-            wind-from-direction
-            relative-humidity]} (extract-constants inputs global-clock cell)
-          fuel-moisture         (or (fuel-moisture-from-raster inputs cell global-clock)
-                                    (get-fuel-moisture relative-humidity temperature))
-          deltas                (sample-wind-dir-deltas inputs
-                                                        fire-line-intensity-matrix
-                                                        (convert/mph->mps wind-speed-20ft)
-                                                        cell)
-          wind-to-direction     (mod (+ 180 wind-from-direction) 360)
-          firebrands            (firebrands deltas wind-to-direction cell cell-size)]
+    (let [tmp               (get-value-at cell
+                                          global-clock
+                                          temperature
+                                          (:temperature multiplier-lookup)
+                                          (:temperature perturbations))
+          rh                (get-value-at cell
+                                          global-clock
+                                          relative-humidity
+                                          (:relative-humidity multiplier-lookup)
+                                          (:relative-humidity perturbations))
+          ws                (get-value-at cell
+                                          global-clock
+                                          wind-speed-20ft
+                                          (:wind-speed-20ft multiplier-lookup)
+                                          (:wind-speed-20ft perturbations))
+          ^double
+          wd                (get-value-at cell
+                                          global-clock
+                                          wind-from-direction
+                                          (:wind-from-direction multiplier-lookup)
+                                          (:wind-from-direction perturbations))
+          fuel-moisture     (or (fuel-moisture-from-raster inputs cell global-clock)
+                                (get-fuel-moisture rh temperature))
+          deltas            (sample-wind-dir-deltas inputs
+                                                    fire-line-intensity-matrix
+                                                    (convert/mph->mps ws)
+                                                    cell)
+          wind-to-direction (mod (+ 180 wd) 360)
+          firebrands        (firebrands deltas wind-to-direction cell cell-size)]
       (update-firebrand-counts! inputs firebrand-count-matrix fire-spread-matrix cell firebrands)
       (->> (for [[x y] firebrands
                  :when (and (in-bounds? num-rows num-cols [x y])
@@ -2820,7 +2854,7 @@ ignition probability.
                         spot-ignition-p (spot-ignition-probability inputs
                                                                    spotting
                                                                    fuel-moisture
-                                                                   temperature
+                                                                   tmp
                                                                    firebrand-count
                                                                    cell
                                                                    [x y])]]
@@ -2828,7 +2862,7 @@ ignition probability.
                (let [[i j] cell
                      t     (spot-ignition-time global-clock
                                                (ft->m (m/mget flame-length-matrix i j))
-                                               (convert/mph->mps wind-speed-20ft))]
+                                               (convert/mph->mps ws))]
                  [[x y] [t spot-ignition-p]])))
            (remove nil?)))))
 #+end_src

--- a/src/gridfire/conversion.clj
+++ b/src/gridfire/conversion.clj
@@ -33,7 +33,8 @@
 
 (defn rad->deg
   "Convert radians to degrees."
-  [d]
+  ^double
+  [^double d]
   (* d (/ 180 Math/PI)))
 
 (defn m->ft

--- a/src/gridfire/utils/random.clj
+++ b/src/gridfire/utils/random.clj
@@ -16,7 +16,6 @@
 
 ;;TODO remove , we can just use my-rand-range
 (defn random-float
-  ^double
   [min-val max-val rand-generator]
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))

--- a/src/gridfire/utils/random.clj
+++ b/src/gridfire/utils/random.clj
@@ -16,6 +16,7 @@
 
 ;;TODO remove , we can just use my-rand-range
 (defn random-float
+  ^double
   [min-val max-val rand-generator]
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))


### PR DESCRIPTION
## Purpose

Adding primitive type hints and casting to improve arithmetic performance.

## Related Issues
Closes GRID-146

## Submission Checklist
- [x] Code passes linter

## Testing
ns to test:
- `gridfire.spotting`

To test:
1. Start repl
2. `(set! *unchecked-math* :warn-on-boxed)`
3. send buffer to the repl (should not have warnings)