### PR TITLE
GRID-146 add type hints misc ns

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1889,7 +1889,8 @@ pseudo-code lays out the steps taken in this procedure:
                                                    burnable-neighbors?
                                                    get-neighbors
                                                    get-value-at
-                                                   sample-at]]
+                                                   sample-at
+                                                   distance-3d]]
             [gridfire.crown-fire          :refer [crown-fire-eccentricity
                                                   crown-fire-line-intensity
                                                   cruz-crown-fire-spread
@@ -1925,15 +1926,6 @@ pseudo-code lays out the steps taken in this procedure:
   [num-rows num-cols]
   [(rand-int num-rows)
    (rand-int num-cols)])
-
-(defn distance-3d
-  "Returns the terrain distance between two points in feet."
-  [elevation-matrix cell-size [i1 j1] [i2 j2]]
-  (let [di (* cell-size (- i1 i2))
-        dj (* cell-size (- j1 j2))
-        dz (- (m/mget elevation-matrix i1 j1)
-              (m/mget elevation-matrix i2 j2))]
-    (Math/sqrt (+ (* di di) (* dj dj) (* dz dz)))))
 
 (def offset-to-degrees
   "Returns clockwise degrees from north."
@@ -4267,23 +4259,23 @@ are meant to be in metric, you must include an entry for the units:
     (mapv #(enrich-info perturbations rand-generator %) (range n))))
 
 (defn value-at
-  ([perturb-info raster here]
+  (^double [perturb-info raster here]
    (value-at perturb-info raster here nil))
 
-  ([{:keys [range spatial-type global-value rand-generator]} raster here frequency-band]
+  (^double [{:keys [range spatial-type global-value rand-generator]} raster here frequency-band]
    (if (= spatial-type :global)
      global-value
      (my-rand-range rand-generator range))))
 
 (defn- update?
-  [global-clock next-clock frequency]
+  [^double global-clock ^double next-clock ^long frequency]
   (< (quot global-clock frequency)
      (quot next-clock frequency)))
 
 (defn- global-temporal-perturbations
   [perturbations]
   (->> perturbations
-       (filter (fn [[k v]] (and (:frequency v) (= (:spatial-type v) :global))))
+       (filter (fn [[_ v]] (and (:frequency v) (= (:spatial-type v) :global))))
        keys))
 
 (defn update-global-vals

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -3565,9 +3565,10 @@ or false:
 
 (defn my-rand
   ([^Random rand-generator] (.nextDouble rand-generator))
-  ([^Random rand-generator n] (* n (my-rand rand-generator))))
+  (^double [^Random rand-generator n] (* n (my-rand rand-generator))))
 
 (defn my-rand-int
+  ^long
   [rand-generator n]
   (int (my-rand rand-generator n)))
 
@@ -3577,6 +3578,7 @@ or false:
 
 ;;TODO remove , we can just use my-rand-range
 (defn random-float
+  ^double
   [min-val max-val rand-generator]
   (let [range (- max-val min-val)]
     (+ min-val (my-rand rand-generator range))))

--- a/src/gridfire/common.clj
+++ b/src/gridfire/common.clj
@@ -3,7 +3,8 @@
    [clojure.core.matrix :as m]
    [gridfire.perturbation :as perturbation]))
 
-(defn matrix-value-at [[i j] global-clock matrix]
+(defn matrix-value-at ^double
+  [[i j] ^double global-clock matrix]
   (if (> (m/dimensionality matrix) 2)
     (let [band (int (quot global-clock 60.0))] ;Assuming each band is 1 hour
       (m/mget matrix band i j))
@@ -15,16 +16,17 @@
 
   ([here global-clock matrix multiplier perturb-info]
    (let [cell       (if multiplier
-                      (mapv #(quot % multiplier) here)
+                      (mapv #(quot ^long % ^long multiplier) here)
                       here)
          value-here (matrix-value-at cell global-clock matrix)]
      (if perturb-info
-       (if-let [freq (:frequency perturb-info)]
-         (+ value-here (perturbation/value-at perturb-info matrix cell (quot global-clock freq)))
+       (if-let [^long freq (:frequency perturb-info)]
+         (+ value-here (perturbation/value-at perturb-info matrix cell (quot ^double global-clock freq)))
          (+ value-here (perturbation/value-at perturb-info matrix cell)))
        value-here))))
 
-(defn get-value-at [here global-clock matrix-or-val multiplier perturb-info]
+(defn get-value-at
+  [here global-clock matrix-or-val multiplier perturb-info]
   (if (> (m/dimensionality matrix-or-val) 1)
     (sample-at here global-clock matrix-or-val multiplier perturb-info)
     matrix-or-val))
@@ -32,10 +34,12 @@
 (defn calc-emc
   "Computes the Equilibrium Moisture Content (EMC) from rh (relative
    humidity in %) and temp (temperature in F)."
-  [rh temp]
-  (/ (cond (< rh 10)  (+ 0.03229 (* 0.281073 rh) (* -0.000578 rh temp))
-           (< rh 50)  (+ 2.22749 (* 0.160107 rh) (* -0.01478 temp))
-           :else (+ 21.0606 (* 0.005565 rh rh) (* -0.00035 rh temp) (* -0.483199 rh)))
+  ^double
+  [^double rh ^double temp]
+  (/ (double
+      (cond (< rh 10)  (+ 0.03229 (* 0.281073 rh) (* -0.000578 rh temp))
+            (< rh 50)  (+ 2.22749 (* 0.160107 rh) (* -0.01478 temp))
+            :else (+ 21.0606 (* 0.005565 rh rh) (* -0.00035 rh temp) (* -0.483199 rh))))
      30))
 
 (defn get-fuel-moisture [relative-humidity temperature]
@@ -53,12 +57,12 @@
                                     global-clock
                                     (:matrix raster)
                                     (get-in multiplier-lookup path))))]
-   (-> fuel-moisture-layers
-       (update-in [:dead :1hr] (f [:dead :1hr]))
-       (update-in [:dead :10hr] (f [:dead :10hr]))
-       (update-in [:dead :100hr] (f [:dead :100hr]))
-       (update-in [:live :herbaceous] (f [:live :herbaceous]))
-       (update-in [:live :woody] (f [:live :woody])))))
+    (-> fuel-moisture-layers
+        (update-in [:dead :1hr] (f [:dead :1hr]))
+        (update-in [:dead :10hr] (f [:dead :10hr]))
+        (update-in [:dead :100hr] (f [:dead :100hr]))
+        (update-in [:live :herbaceous] (f [:live :herbaceous]))
+        (update-in [:live :woody] (f [:live :woody])))))
 
 (defn fuel-moisture-from-raster
   "Returns a map of moisture
@@ -72,11 +76,11 @@
 
   ([{:keys [fuel-moisture-layers multiplier-lookup]} here global-clock]
    (when fuel-moisture-layers
-    (extract-fuel-moisture fuel-moisture-layers multiplier-lookup here global-clock))))
+     (extract-fuel-moisture fuel-moisture-layers multiplier-lookup here global-clock))))
 
 (defn in-bounds?
   "Returns true if the point lies within the bounds [0,rows) by [0,cols)."
-  [rows cols [i j]]
+  [^long rows ^long cols [^long i ^long j]]
   (and (>= i 0)
        (>= j 0)
        (< i rows)
@@ -91,16 +95,19 @@
 (defn burnable?
   "Returns true if cell [x y] has not yet been ignited (but could be)."
   [fire-spread-matrix fuel-model-matrix [i j :as source] [x y :as here]]
-  (let [source-ignition-probability (m/mget fire-spread-matrix i j)]
-    (and (< (m/mget fire-spread-matrix x y) (if (= source-ignition-probability 0.0)
-                                              1.0
-                                              source-ignition-probability))
+  (let [^double ignition-probability-here   (m/mget fire-spread-matrix x y)
+        ^double source-ignition-probability (m/mget fire-spread-matrix i j)]
+    (and (< ignition-probability-here ^double (if (= source-ignition-probability 0.0)
+                                                1.0
+                                                source-ignition-probability))
          (burnable-fuel-model? (m/mget fuel-model-matrix x y)))))
 
 (defn get-neighbors
   "Returns the eight points adjacent to the passed-in point."
   [[i j]]
-  (let [i- (- i 1)
+  (let [i (long i)
+        j (long j)
+        i- (- i 1)
         i+ (+ i 1)
         j- (- j 1)
         j+ (+ j 1)]
@@ -116,9 +123,14 @@
 
 (defn distance-3d
   "Returns the terrain distance between two points in feet."
-  [elevation-matrix cell-size [i1 j1] [i2 j2]]
-  (let [di (* cell-size (- i1 i2))
+  ^double
+  [elevation-matrix ^double cell-size [i1 j1] [i2 j2]]
+  (let [i1 (long i1)
+        j1 (long j1)
+        i2 (long i2)
+        j2 (long j2)
+        di (* cell-size (- i1 i2))
         dj (* cell-size (- j1 j2))
-        dz (- (m/mget elevation-matrix i1 j1)
-              (m/mget elevation-matrix i2 j2))]
+        dz (- ^double (m/mget elevation-matrix i1 j1)
+              ^double (m/mget elevation-matrix i2 j2))]
     (Math/sqrt (+ (* di di) (* dj dj) (* dz dz)))))

--- a/src/gridfire/conversion.clj
+++ b/src/gridfire/conversion.clj
@@ -3,32 +3,37 @@
 
 (defn F->K
   "Convert farenheight to kelvin."
-  [degrees]
+  ^double
+  [^double degrees]
   (->> (+ degrees 459.67)
        (* (/ 5.0 9.0))))
 
 (defn K->F
   "Convert kelvin to farenheight."
-  [degrees]
+  ^double
+  [^double degrees]
   (->> (- degrees 273.15)
        (* (/ 9.0 5.0))
        (+ 32.0)))
 
 (defn F->C
   "Convert farenheight to celcius."
-  [degrees]
+  ^double
+  [^double degrees]
   (->> (- degrees 32.0)
        (* (/ 5.0 9.0))))
 
 (defn C->F
   "Convert celsius to farenheight."
-  [degrees]
+  ^double
+  [^double degrees]
   (->> (* degrees (/ 9.0 5.0))
        (+ 32.0)))
 
 (defn deg->rad
   "Convert degrees to radians."
-  [d]
+  ^double
+  [^double d]
   (* d (/ Math/PI 180)))
 
 (defn rad->deg
@@ -39,30 +44,36 @@
 
 (defn m->ft
   "Convert meters to feet."
-  [m]
+  ^double
+  [^double m]
   (* m 3.281))
 
 (defn mph->mps
   "Convert miles per hour to meters per second."
-  [s]
+  ^double
+  [^double s]
   (* s 0.447))
 
 (defn Btu-ft-s->kW-m
   "Convert BTU per feet per second to kilowatt per meter."
-  [Btu-ft-s]
+  ^double
+  [^double Btu-ft-s]
   (/ Btu-ft-s 0.288894658272))
 
 (defn percent->dec
-  [p]
+  ^double
+  [^double p]
   (* p 0.001))
 
 (defn dec->percent
-  [d]
+  ^double
+  [^double d]
   (* d 100))
 
 (defn sec->min
   "Convert seconds to minutes."
-  [s]
+  ^double
+  [^double s]
   (/ s 60))
 
 (def conversion-table
@@ -70,61 +81,61 @@
    :slope              deg->rad
    :canopy-height      m->ft
    :canopy-base-height m->ft
-   :crown-bulk-density #(* % 0.0624) ; kg/m^3 -> lb/ft^3
-   :wind-speed-20ft    #(* % 2.237)  ; m/s -> mph
+   :crown-bulk-density #(* ^double % 0.0624) ; kg/m^3 -> lb/ft^3
+   :wind-speed-20ft    #(* ^double % 2.237)  ; m/s -> mph
    :temperature        {:metric   C->F
                         :absolute K->F}})
 
 (defmulti to-imperial (fn [_ _ layer-name] layer-name))
 
 (defmethod to-imperial :elevation
-  [layer {:keys [units multiplier]} layer-name]
+  [layer {:keys [units ^double multiplier]} layer-name]
   (if-let [xforms (seq (remove nil? [(when (= units :metric) (conversion-table layer-name))
-                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* % multiplier))]))]
+                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* ^double % multiplier))]))]
     (update layer :matrix (fn [matrix] (m/emap (apply comp xforms) matrix)))
     layer))
 
 (defmethod to-imperial :slope
-  [layer {:keys [multiplier]} layer-name]
+  [layer {:keys [^double multiplier]} layer-name]
   (if-let [xforms (seq (remove nil? [(conversion-table layer-name)
-                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* % multiplier))]))]
+                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* ^double % multiplier))]))]
     (update layer :matrix (fn [matrix] (m/emap (apply comp xforms) matrix)))
     layer))
 
 (defmethod to-imperial :canopy-height
-  [layer {:keys [units multiplier]} layer-name]
+  [layer {:keys [units ^double multiplier]} layer-name]
   (if-let [xforms (seq (remove nil? [(when (= units :metric) (conversion-table layer-name))
-                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* % multiplier))]))]
+                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* ^double % multiplier))]))]
     (update layer :matrix (fn [matrix] (m/emap (apply comp xforms) matrix)))
     layer))
 
 (defmethod to-imperial :canopy-base-height
-  [layer {:keys [units multiplier]} layer-name]
+  [layer {:keys [units ^double multiplier]} layer-name]
   (if-let [xforms (seq (remove nil? [(when (= units :metric) (conversion-table layer-name))
-                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* % multiplier))]))]
+                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* ^double % multiplier))]))]
     (update layer :matrix (fn [matrix] (m/emap (apply comp xforms) matrix)))
     layer))
 
 (defmethod to-imperial :crown-bulk-density
-  [layer {:keys [units multiplier]} layer-name]
+  [layer {:keys [units ^double multiplier]} layer-name]
   (if-let [xforms (seq (remove nil? [(when (= units :metric) (conversion-table layer-name))
-                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* % multiplier))]))]
+                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* ^double % multiplier))]))]
     (update layer :matrix (fn [matrix] (m/emap (apply comp xforms) matrix)))
     layer))
 
 (defmethod to-imperial :wind-speed-20ft
-  [layer {:keys [units multiplier]} layer-name]
+  [layer {:keys [units ^double multiplier]} layer-name]
   (if-let [xforms (seq (remove nil? [(when (= units :metric) (conversion-table layer-name))
-                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* % multiplier))]))]
+                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* ^double % multiplier))]))]
     (update layer :matrix (fn [matrix] (m/emap (apply comp xforms) matrix)))
     layer))
 
 (defmethod to-imperial :temperature
-  [layer {:keys [units multiplier]} layer-name]
+  [layer {:keys [units ^double multiplier]} layer-name]
   (if-let [xforms (seq (remove nil? [(cond
                                        (= units :metric)   (get-in conversion-table [layer-name units])
                                        (= units :absolute) (get-in conversion-table [layer-name units]))
-                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* % multiplier))]))]
+                                     (when-not (contains? #{1 1.0 nil} multiplier) #(* ^double % multiplier))]))]
     (update layer :matrix (fn [matrix] (m/emap (apply comp xforms) matrix)))
     layer))
 

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -11,7 +11,8 @@
                                                    burnable-neighbors?
                                                    get-neighbors
                                                    get-value-at
-                                                   sample-at]]
+                                                   sample-at
+                                                   distance-3d]]
             [gridfire.crown-fire          :refer [crown-fire-eccentricity
                                                   crown-fire-line-intensity
                                                   cruz-crown-fire-spread
@@ -47,15 +48,6 @@
   [num-rows num-cols]
   [(rand-int num-rows)
    (rand-int num-cols)])
-
-(defn distance-3d
-  "Returns the terrain distance between two points in feet."
-  [elevation-matrix cell-size [i1 j1] [i2 j2]]
-  (let [di (* cell-size (- i1 i2))
-        dj (* cell-size (- j1 j2))
-        dz (- (m/mget elevation-matrix i1 j1)
-              (m/mget elevation-matrix i2 j2))]
-    (Math/sqrt (+ (* di di) (* dj dj) (* dz dz)))))
 
 (def offset-to-degrees
   "Returns clockwise degrees from north."

--- a/src/gridfire/perturbation.clj
+++ b/src/gridfire/perturbation.clj
@@ -48,23 +48,23 @@
     (mapv #(enrich-info perturbations rand-generator %) (range n))))
 
 (defn value-at
-  ([perturb-info raster here]
+  (^double [perturb-info raster here]
    (value-at perturb-info raster here nil))
 
-  ([{:keys [range spatial-type global-value rand-generator]} raster here frequency-band]
+  (^double [{:keys [range spatial-type global-value rand-generator]} raster here frequency-band]
    (if (= spatial-type :global)
      global-value
      (my-rand-range rand-generator range))))
 
 (defn- update?
-  [global-clock next-clock frequency]
+  [^double global-clock ^double next-clock ^long frequency]
   (< (quot global-clock frequency)
      (quot next-clock frequency)))
 
 (defn- global-temporal-perturbations
   [perturbations]
   (->> perturbations
-       (filter (fn [[k v]] (and (:frequency v) (= (:spatial-type v) :global))))
+       (filter (fn [[_ v]] (and (:frequency v) (= (:spatial-type v) :global))))
        keys))
 
 (defn update-global-vals

--- a/src/gridfire/utils/random.clj
+++ b/src/gridfire/utils/random.clj
@@ -4,9 +4,10 @@
 
 (defn my-rand
   ([^Random rand-generator] (.nextDouble rand-generator))
-  ([^Random rand-generator n] (* n (my-rand rand-generator))))
+  (^double [^Random rand-generator n] (* n (my-rand rand-generator))))
 
 (defn my-rand-int
+  ^long
   [rand-generator n]
   (int (my-rand rand-generator n)))
 


### PR DESCRIPTION
## Purpose

Adding primitive type hints and casting to improve arithmetic performance.

## Related Issues
Closes GRID-146

## Submission Checklist
- [x] Code passes linter

## Testing
ns to test:
- `gridfire.conversion`
- `gridfire.fires-spread`
- `gridfire.perturbation`

These ns are only partially type hinted
- `gridfire.random`

To test:
1. Start repl
2. `(set! *unchecked-math* :warn-on-boxed)`
3. send buffer to the repl (should not have warnings)