### PR TITLE
GRID-159 MISC fixes when comparing GRIDFIRE to ELMFIRE

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2248,8 +2248,10 @@ pseudo-code lays out the steps taken in this procedure:
            spread-rate-matrix
            fire-type-matrix] :as matrices}
    ignited-cells]
-  (let [max-runtime (double max-runtime)
-        cell-size   (double cell-size)]
+  (let [max-runtime      (double max-runtime)
+        cell-size        (double cell-size)
+        crown-fire-count (atom 0)
+        spot-count       (atom 0)]
    (loop [global-clock   0.0
           ignited-cells  ignited-cells
           spot-ignitions {}]
@@ -2270,9 +2272,10 @@ pseudo-code lays out the steps taken in this procedure:
          (doseq [{:keys
                   [cell flame-length fire-line-intensity
                    ignition-probability spread-rate fire-type
-                   dt-adjusted]} ignition-events]
+                   dt-adjusted crown-fire?]} ignition-events]
            (let [[i j]       cell
                  dt-adjusted (double dt-adjusted)]
+             (when crown-fire? (swap! crown-fire-count inc))
              (m/mset! fire-spread-matrix         i j ignition-probability)
              (m/mset! flame-length-matrix        i j flame-length)
              (m/mset! fire-line-intensity-matrix i j fire-line-intensity)
@@ -2291,6 +2294,7 @@ pseudo-code lays out the steps taken in this procedure:
                                                       global-clock
                                                       matrices
                                                       spot-ignite-now)]
+           (reset! spot-count (+ @spot-count (count spot-ignited-cells)))
            (recur next-global-clock
                   (update-ignited-cells inputs
                                         (into spot-ignited-cells ignited-cells)
@@ -2305,7 +2309,9 @@ pseudo-code lays out the steps taken in this procedure:
         :fire-line-intensity-matrix fire-line-intensity-matrix
         :burn-time-matrix           burn-time-matrix
         :spread-rate-matrix         spread-rate-matrix
-        :fire-type-matrix           fire-type-matrix}))))
+        :fire-type-matrix           fire-type-matrix
+        :crown-fire-count           @crown-fire-count
+        :spot-count                 @spot-count}))))
 
 (defn- initialize-matrix
   [num-rows num-cols indices]
@@ -3128,6 +3134,7 @@ or false:
         fire-line-intensities      (filterv pos? (m/eseq (:fire-line-intensity-matrix fire-spread-results)))
         burned-cells               (count flame-lengths)
         fire-size                  (cells-to-acres cell-size burned-cells)
+        crown-fire-size            (cells-to-acres cell-size (:crown-fire-count fire-spread-results))
         flame-length-mean          (/ (m/esum flame-lengths) burned-cells)
         fire-line-intensity-mean   (/ (m/esum fire-line-intensities) burned-cells)
         flame-length-stddev        (->> flame-lengths
@@ -3141,10 +3148,12 @@ or false:
                                         (#(/ % burned-cells))
                                         (Math/sqrt))]
     {:fire-size                  fire-size
+     :crown-fire-size            crown-fire-size
      :flame-length-mean          flame-length-mean
      :flame-length-stddev        flame-length-stddev
      :fire-line-intensity-mean   fire-line-intensity-mean
-     :fire-line-intensity-stddev fire-line-intensity-stddev}))
+     :fire-line-intensity-stddev fire-line-intensity-stddev
+     :spot-count                 (:spot-count fire-spread-results)}))
 
 (defn calc-ffwi
   "Computes the Fosberg Fire Weather Index value from rh (relative
@@ -3463,11 +3472,12 @@ or false:
      (when output-csvs?
        (merge
         input-variations
-        {:simulation      (inc i)
-         :ignition-row    (ignition-rows i)
-         :ignition-col    (ignition-cols i)
-         :foliar-moisture (foliar-moistures i)
-         :exit-condition  (:exit-condition fire-spread-results :no-fire-spread)}
+        {:simulation       (inc i)
+         :ignition-row     (ignition-rows i)
+         :ignition-col     (ignition-cols i)
+         :foliar-moisture  (foliar-moistures i)
+         :exit-condition   (:exit-condition fire-spread-results :no-fire-spread)
+         :crown-fire-count (:crown-fire-count fire-spread-results)}
         (if fire-spread-results
           (tufte/p
            :summarize-fire-spread-results
@@ -3536,7 +3546,7 @@ or false:
              (mapv (fn [{:keys [ignition-row ignition-col max-runtime temperature relative-humidity
                                 wind-speed-20ft wind-from-direction foliar-moisture ellipse-adjustment-factor
                                 fire-size flame-length-mean flame-length-stddev fire-line-intensity-mean
-                                fire-line-intensity-stddev simulation]}]
+                                fire-line-intensity-stddev simulation crown-fire-size spot-count]}]
                      [simulation
                       ignition-row
                       ignition-col
@@ -3551,10 +3561,12 @@ or false:
                       flame-length-mean
                       flame-length-stddev
                       fire-line-intensity-mean
-                      fire-line-intensity-stddev]))
+                      fire-line-intensity-stddev
+                      crown-fire-size
+                      spot-count]))
              (cons ["simulation" "ignition-row" "ignition-col" "max-runtime" "temperature" "relative-humidity" "wind-speed-20ft"
                     "wind-from-direction" "foliar-moisture" "ellipse-adjustment-factor" "fire-size" "flame-length-mean"
-                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev"])
+                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev" "crown-fire-size" "spot-count"])
              (csv/write-csv out-file))))))
 
 ;; FIXME: Add a program banner and better usage/error messages

--- a/resources/build_geoserver_directory.sh
+++ b/resources/build_geoserver_directory.sh
@@ -16,7 +16,7 @@ mkdir geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/
 
 for BP in 10 30 50 70 90; do
     mkdir ./geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/$BP
-    cp ./imagemosaic/*.properties ./geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/$BP/
+    cp ./imagemosaic_properties.zip ./geoserver/$FIRENAME/${START_DATE}_${START_TIME}/gridfire/landfire/$BP/
 done
 
 rename () {

--- a/resources/elmfire_post.sh
+++ b/resources/elmfire_post.sh
@@ -8,6 +8,7 @@ fi
 ELMFIRE_POST=elmfire_post_$ELMFIRE_VER
 MPIRUN=/usr/bin/mpirun
 HOSTS=`printf "$(hostname),%.0s" {1..64}`
+NP=`cat /proc/cpuinfo | grep "cpu cores" | cut -d: -f2 | tail -n 1 | xargs`
 CELLSIZE=`cat ../elmfire.data | grep COMPUTATIONAL_DOMAIN_CELLSIZE | cut -d= -f2 | xargs`
 XLLCORNER=`cat ../elmfire.data | grep COMPUTATIONAL_DOMAIN_XLLCORNER | cut -d= -f2 | xargs`
 YLLCORNER=`cat ../elmfire.data | grep COMPUTATIONAL_DOMAIN_YLLCORNER | cut -d= -f2 | xargs`
@@ -38,6 +39,6 @@ echo "DUMP_SPREAD_RATE = .FALSE."                     >> elmfire_post.data
 echo "DUMP_CROWN_FIRE = .FALSE."                      >> elmfire_post.data
 echo "/"                                              >> elmfire_post.data
 
-OMP_PROC_BIND=true $MPIRUN --mca btl tcp,self,vader --map-by core --bind-to core --use-hwthread-cpus -host $HOSTS $ELMFIRE_POST elmfire_post.data 1> /dev/null
+$MPIRUN --mca btl tcp,self,vader --map-by core --bind-to core -np $NP -host $HOSTS $ELMFIRE_POST elmfire_post.data 2> /dev/null
 
 echo "Built .bil & .hdr files"

--- a/resources/upload_tarball.sh
+++ b/resources/upload_tarball.sh
@@ -6,7 +6,7 @@ START_DATE=`echo $(pwd) | rev | cut -d'/' -f2 | rev | cut -d_ -f2`
 START_TIME=`echo $(pwd) | rev | cut -d'/' -f2 | rev | cut -d_ -f3`
 
 cd geoserver
-scp  $MODEL-$FIRENAME-${START_DATE}_${START_TIME}.tar gridfire@data.pyregence.org:/incoming/
+scp  $MODEL-$FIRENAME-${START_DATE}_${START_TIME}.tar gridfire@data.pyregence.org:/incoming/match_drop/
 mv *.tar ..
 ssh gridfire@data.pyregence.org \
     tar -xf /incoming/match_drop/$MODEL-$FIRENAME-${START_DATE}_${START_TIME}.tar \

--- a/resources/upload_tarball.sh
+++ b/resources/upload_tarball.sh
@@ -9,7 +9,7 @@ cd geoserver
 scp  $MODEL-$FIRENAME-${START_DATE}_${START_TIME}.tar gridfire@data.pyregence.org:/incoming/
 mv *.tar ..
 ssh gridfire@data.pyregence.org \
-    tar -xf /incoming/$MODEL-$FIRENAME-${START_DATE}_${START_TIME}.tar \
+    tar -xf /incoming/match_drop/$MODEL-$FIRENAME-${START_DATE}_${START_TIME}.tar \
     -C /var/www/html/fire_spread_forecast
 
 echo "Uploaded tarball to GeoServer"

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -59,7 +59,8 @@
      :flame-length-mean          flame-length-mean
      :flame-length-stddev        flame-length-stddev
      :fire-line-intensity-mean   fire-line-intensity-mean
-     :fire-line-intensity-stddev fire-line-intensity-stddev}))
+     :fire-line-intensity-stddev fire-line-intensity-stddev
+     :spot-count                 (:spot-count fire-spread-results)}))
 
 (defn calc-ffwi
   "Computes the Fosberg Fire Weather Index value from rh (relative
@@ -452,7 +453,7 @@
              (mapv (fn [{:keys [ignition-row ignition-col max-runtime temperature relative-humidity
                                 wind-speed-20ft wind-from-direction foliar-moisture ellipse-adjustment-factor
                                 fire-size flame-length-mean flame-length-stddev fire-line-intensity-mean
-                                fire-line-intensity-stddev simulation crown-fire-size]}]
+                                fire-line-intensity-stddev simulation crown-fire-size spot-count]}]
                      [simulation
                       ignition-row
                       ignition-col
@@ -468,10 +469,11 @@
                       flame-length-stddev
                       fire-line-intensity-mean
                       fire-line-intensity-stddev
-                      crown-fire-size]))
+                      crown-fire-size
+                      spot-count]))
              (cons ["simulation" "ignition-row" "ignition-col" "max-runtime" "temperature" "relative-humidity" "wind-speed-20ft"
                     "wind-from-direction" "foliar-moisture" "ellipse-adjustment-factor" "fire-size" "flame-length-mean"
-                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev" "crown-fire-size"])
+                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev" "crown-fire-size" "spot-count"])
              (csv/write-csv out-file))))))
 
 ;; FIXME: Add a program banner and better usage/error messages

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -57,7 +57,8 @@
      :flame-length-mean          flame-length-mean
      :flame-length-stddev        flame-length-stddev
      :fire-line-intensity-mean   fire-line-intensity-mean
-     :fire-line-intensity-stddev fire-line-intensity-stddev}))
+     :fire-line-intensity-stddev fire-line-intensity-stddev
+     :crown-fire-count           (:crown-fire-count fire-spread-results)}))
 
 (defn calc-ffwi
   "Computes the Fosberg Fire Weather Index value from rh (relative
@@ -450,7 +451,7 @@
              (mapv (fn [{:keys [ignition-row ignition-col max-runtime temperature relative-humidity
                                 wind-speed-20ft wind-from-direction foliar-moisture ellipse-adjustment-factor
                                 fire-size flame-length-mean flame-length-stddev fire-line-intensity-mean
-                                fire-line-intensity-stddev simulation]}]
+                                fire-line-intensity-stddev simulation crown-fire-count]}]
                      [simulation
                       ignition-row
                       ignition-col
@@ -465,10 +466,11 @@
                       flame-length-mean
                       flame-length-stddev
                       fire-line-intensity-mean
-                      fire-line-intensity-stddev]))
+                      fire-line-intensity-stddev
+                      crown-fire-count]))
              (cons ["simulation" "ignition-row" "ignition-col" "max-runtime" "temperature" "relative-humidity" "wind-speed-20ft"
                     "wind-from-direction" "foliar-moisture" "ellipse-adjustment-factor" "fire-size" "flame-length-mean"
-                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev"])
+                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev" "crown-fire-count"])
              (csv/write-csv out-file))))))
 
 ;; FIXME: Add a program banner and better usage/error messages

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -41,6 +41,7 @@
         fire-line-intensities      (filterv pos? (m/eseq (:fire-line-intensity-matrix fire-spread-results)))
         burned-cells               (count flame-lengths)
         fire-size                  (cells-to-acres cell-size burned-cells)
+        crown-fire-size            (cells-to-acres cell-size (:crown-fire-count fire-spread-results))
         flame-length-mean          (/ (m/esum flame-lengths) burned-cells)
         fire-line-intensity-mean   (/ (m/esum fire-line-intensities) burned-cells)
         flame-length-stddev        (->> flame-lengths
@@ -54,11 +55,11 @@
                                         (#(/ % burned-cells))
                                         (Math/sqrt))]
     {:fire-size                  fire-size
+     :crown-fire-size            crown-fire-size
      :flame-length-mean          flame-length-mean
      :flame-length-stddev        flame-length-stddev
      :fire-line-intensity-mean   fire-line-intensity-mean
-     :fire-line-intensity-stddev fire-line-intensity-stddev
-     :crown-fire-count           (:crown-fire-count fire-spread-results)}))
+     :fire-line-intensity-stddev fire-line-intensity-stddev}))
 
 (defn calc-ffwi
   "Computes the Fosberg Fire Weather Index value from rh (relative
@@ -451,7 +452,7 @@
              (mapv (fn [{:keys [ignition-row ignition-col max-runtime temperature relative-humidity
                                 wind-speed-20ft wind-from-direction foliar-moisture ellipse-adjustment-factor
                                 fire-size flame-length-mean flame-length-stddev fire-line-intensity-mean
-                                fire-line-intensity-stddev simulation crown-fire-count]}]
+                                fire-line-intensity-stddev simulation crown-fire-size]}]
                      [simulation
                       ignition-row
                       ignition-col
@@ -467,10 +468,10 @@
                       flame-length-stddev
                       fire-line-intensity-mean
                       fire-line-intensity-stddev
-                      crown-fire-count]))
+                      crown-fire-size]))
              (cons ["simulation" "ignition-row" "ignition-col" "max-runtime" "temperature" "relative-humidity" "wind-speed-20ft"
                     "wind-from-direction" "foliar-moisture" "ellipse-adjustment-factor" "fire-size" "flame-length-mean"
-                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev" "crown-fire-count"])
+                    "flame-length-stddev" "fire-line-intensity-mean" "fire-line-intensity-stddev" "crown-fire-size"])
              (csv/write-csv out-file))))))
 
 ;; FIXME: Add a program banner and better usage/error messages

--- a/src/gridfire/cli.clj
+++ b/src/gridfire/cli.clj
@@ -376,11 +376,12 @@
      (when output-csvs?
        (merge
         input-variations
-        {:simulation      (inc i)
-         :ignition-row    (ignition-rows i)
-         :ignition-col    (ignition-cols i)
-         :foliar-moisture (foliar-moistures i)
-         :exit-condition  (:exit-condition fire-spread-results :no-fire-spread)}
+        {:simulation       (inc i)
+         :ignition-row     (ignition-rows i)
+         :ignition-col     (ignition-cols i)
+         :foliar-moisture  (foliar-moistures i)
+         :exit-condition   (:exit-condition fire-spread-results :no-fire-spread)
+         :crown-fire-count (:crown-fire-count fire-spread-results)}
         (if fire-spread-results
           (tufte/p
            :summarize-fire-spread-results

--- a/src/gridfire/common.clj
+++ b/src/gridfire/common.clj
@@ -21,8 +21,8 @@
          value-here (matrix-value-at cell global-clock matrix)]
      (if perturb-info
        (if-let [^long freq (:frequency perturb-info)]
-         (+ value-here (perturbation/value-at perturb-info matrix cell (quot ^double global-clock freq)))
-         (+ value-here (perturbation/value-at perturb-info matrix cell)))
+         (max 0 (+ value-here (perturbation/value-at perturb-info matrix cell (quot ^double global-clock freq))))
+         (max 0 (+ value-here (perturbation/value-at perturb-info matrix cell))))
        value-here))))
 
 (defn get-value-at

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -330,7 +330,7 @@
     (->> {:cell-size                 (convert/m->ft COMPUTATIONAL_DOMAIN_CELLSIZE)
           :srid                      A_SRS
           :max-runtime               (sec->min SIMULATION_TSTOP)
-          :simulations               50
+          :simulations               100
           :random-seed               SEED
           :foliar-moisture           FOLIAR_MOISTURE_CONTENT
           :ellipse-adjustment-factor 1.0

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -69,7 +69,8 @@
                                                    :multiplier 0.1}
                               :crown-bulk-density {:type   :geotiff
                                                    :source (file-path dir CBD_FILENAME)
-                                                   :units  :metric}
+                                                   :units  :metric
+                                                   :multiplier 0.01}
                               :elevation          {:type   :geotiff
                                                    :source (file-path dir DEM_FILENAME)
                                                    :units  :metric}

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -225,16 +225,16 @@
      ENABLE_SPOTTING] :as data}]
   (if (or GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT_MIN)
     (if ENABLE_SPOTTING
-      [[[1 204] [GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT_MIN GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT_MAX]]]
-      [[[1 204] GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT]])
+      [[[1 204] [(* 0.01 GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT_MIN) (* 0.01 GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT_MAX)]]]
+      [[[1 204] (* 0.01 GLOBAL_SURFACE_FIRE_SPOTTING_PERCENT)]])
     (extract-surface-spotting-percents data)))
 
 (defn extract-crown-fire-spotting-percent
   [{:strs [CROWN_FIRE_SPOTTING_PERCENT_MIN CROWN_FIRE_SPOTTING_PERCENT_MAX
            CROWN_FIRE_SPOTTING_PERCENT ENABLE_SPOTTING]}]
   (if ENABLE_SPOTTING
-    [CROWN_FIRE_SPOTTING_PERCENT_MIN CROWN_FIRE_SPOTTING_PERCENT_MAX]
-    CROWN_FIRE_SPOTTING_PERCENT))
+    [(* 0.01 CROWN_FIRE_SPOTTING_PERCENT_MIN) (* 0.01 CROWN_FIRE_SPOTTING_PERCENT_MAX)]
+    (* 0.01 CROWN_FIRE_SPOTTING_PERCENT)))
 
 (defn extract-num-firebrands
   [{:strs [NEMBERS NEMBERS_MIN NEMBERS_MIN_LO NEMBERS_MIN_HI NEMBERS_MAX
@@ -286,7 +286,7 @@
                             ENABLE_SURFACE_FIRE_SPOTTING
                             (assoc-in [:spotting :surface-fire-spotting]
                                       {:spotting-percent             (extract-global-surface-spotting-percents data)
-                                       :critical-fire-line-intensity CRITICAL_SPOTTING_FIRELINE_INTENSITY}))]
+                                       :critical-fire-line-intensity (convert/kW-m->Btu-ft-s CRITICAL_SPOTTING_FIRELINE_INTENSITY)}))]
       (merge config spotting-config))
     config))
 

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -323,11 +323,11 @@
     (->> {:cell-size                 (convert/m->ft COMPUTATIONAL_DOMAIN_CELLSIZE)
           :srid                      A_SRS
           :max-runtime               (sec->min SIMULATION_TSTOP)
-          :simulations               10
+          :simulations               100
           :random-seed               SEED
           :foliar-moisture           FOLIAR_MOISTURE_CONTENT
           :ellipse-adjustment-factor 1.0
-          :parallel-strategy         :within-fires}
+          :parallel-strategy         :between-fires}
          (process-landfire-layers data options)
          (process-ignition data options)
          (process-weather data options)

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -330,7 +330,7 @@
     (->> {:cell-size                 (convert/m->ft COMPUTATIONAL_DOMAIN_CELLSIZE)
           :srid                      A_SRS
           :max-runtime               (sec->min SIMULATION_TSTOP)
-          :simulations               100
+          :simulations               50
           :random-seed               SEED
           :foliar-moisture           FOLIAR_MOISTURE_CONTENT
           :ellipse-adjustment-factor 1.0

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -175,7 +175,7 @@
 
 (defn extract-perturbations
   [{:strs [NUM_RASTERS_TO_PERTURB] :as config}]
-  (when (pos? NUM_RASTERS_TO_PERTURB)
+  (when (and NUM_RASTERS_TO_PERTURB (pos? NUM_RASTERS_TO_PERTURB))
     (into {}
           (map (fn [index]
                  (when-let [key (perturbation-key config index)]
@@ -191,13 +191,19 @@
                  [layer spec])))
         config))
 
+(defn remove-unused-perturbations
+  [config]
+  (dissoc config :crown-bulk-density :canopy-base-height))
+
 (defn process-perturbations
   [data _ config]
   (let [perturbations (-> (extract-perturbations data)
-                          (add-units))]
-    (when (seq perturbations)
+                          (add-units)
+                          remove-unused-perturbations)]
+    (if (seq perturbations)
       (merge config
-             {:perturbations perturbations}))))
+             {:perturbations perturbations})
+      config)))
 
 ;;-----------------------------------------------------------------------------
 ;; Spotting

--- a/src/gridfire/conversion.clj
+++ b/src/gridfire/conversion.clj
@@ -60,6 +60,12 @@
   [^double Btu-ft-s]
   (/ Btu-ft-s 0.288894658272))
 
+(defn kW-m->Btu-ft-s
+  "Convert kilowatt per meter to BTU per feet per second"
+  ^double
+  [^double kW-m]
+  (* kW-m 0.288894658272))
+
 (defn percent->dec
   ^double
   [^double p]

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -370,9 +370,10 @@
            spread-rate-matrix
            fire-type-matrix] :as matrices}
    ignited-cells]
-  (let [max-runtime (double max-runtime)
-        cell-size   (double cell-size)
-        crown-fire-count (atom 0)]
+  (let [max-runtime      (double max-runtime)
+        cell-size        (double cell-size)
+        crown-fire-count (atom 0)
+        spot-count       (atom 0)]
    (loop [global-clock   0.0
           ignited-cells  ignited-cells
           spot-ignitions {}]
@@ -415,6 +416,7 @@
                                                       global-clock
                                                       matrices
                                                       spot-ignite-now)]
+           (reset! spot-count (+ @spot-count (count spot-ignited-cells)))
            (recur next-global-clock
                   (update-ignited-cells inputs
                                         (into spot-ignited-cells ignited-cells)
@@ -430,7 +432,8 @@
         :burn-time-matrix           burn-time-matrix
         :spread-rate-matrix         spread-rate-matrix
         :fire-type-matrix           fire-type-matrix
-        :crown-fire-count           @crown-fire-count}))))
+        :crown-fire-count           @crown-fire-count
+        :spot-count                 @spot-count}))))
 
 (defn- initialize-matrix
   [num-rows num-cols indices]

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -371,7 +371,8 @@
            fire-type-matrix] :as matrices}
    ignited-cells]
   (let [max-runtime (double max-runtime)
-        cell-size   (double cell-size)]
+        cell-size   (double cell-size)
+        crown-fire-count (atom 0)]
    (loop [global-clock   0.0
           ignited-cells  ignited-cells
           spot-ignitions {}]
@@ -392,9 +393,10 @@
          (doseq [{:keys
                   [cell flame-length fire-line-intensity
                    ignition-probability spread-rate fire-type
-                   dt-adjusted]} ignition-events]
+                   dt-adjusted crown-fire?]} ignition-events]
            (let [[i j]       cell
                  dt-adjusted (double dt-adjusted)]
+             (when crown-fire? (swap! crown-fire-count inc))
              (m/mset! fire-spread-matrix         i j ignition-probability)
              (m/mset! flame-length-matrix        i j flame-length)
              (m/mset! fire-line-intensity-matrix i j fire-line-intensity)
@@ -427,7 +429,8 @@
         :fire-line-intensity-matrix fire-line-intensity-matrix
         :burn-time-matrix           burn-time-matrix
         :spread-rate-matrix         spread-rate-matrix
-        :fire-type-matrix           fire-type-matrix}))))
+        :fire-type-matrix           fire-type-matrix
+        :crown-fire-count           @crown-fire-count}))))
 
 (defn- initialize-matrix
   [num-rows num-cols indices]


### PR DESCRIPTION
## Purpose

When comparing GF to ELM misc fixes were identified
Findings:

- Sample-at should return positive values only

- Config conversion

  - Perturbations, remove CBH and CBD since ELMFIRE does not implment this

  - Landfire Layer: CBD should have multiplier 0.01

- Update upload_tarball.sh to push to /incoming/match_drop directory

- Update build_geoserver.sh to copy imagemosaic_properties.zip

- Add crown fire and spot-count to summary.csv

## Related Issues
Closes GRID-159

## Submission Checklist
- [x] Code passes linter

## Testing