### PR TITLE
GRID-160 Implementation for fractinoal distance handling according to Morais2001

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2061,22 +2061,22 @@ pseudo-code lays out the steps taken in this procedure:
                                                  (:slope perturbations))
         ^double relative-humidity     (get-value-at here
                                                     global-clock
-                                                    relative-humidity
+                                                    (first relative-humidity)
                                                     (:relative-humidity multiplier-lookup)
                                                     (:relative-humidity perturbations))
         ^double temperature           (get-value-at here
                                                     global-clock
-                                                    temperature
+                                                    (first temperature)
                                                     (:temperature multiplier-lookup)
                                                     (:temperature perturbations))
         ^double wind-from-direction   (get-value-at here
                                                     global-clock
-                                                    wind-from-direction
+                                                    (first wind-from-direction)
                                                     (:wind-from-direction multiplier-lookup)
                                                     (:wind-from-direction perturbations))
         ^double wind-speed-20ft       (get-value-at here
                                                     global-clock
-                                                    wind-speed-20ft
+                                                    (first wind-speed-20ft)
                                                     (:wind-speed-20ft multiplier-lookup)
                                                     (:wind-speed-20ft perturbations))
         ^double fuel-moisture         (or (fuel-moisture-from-raster constants here global-clock)
@@ -2104,32 +2104,69 @@ pseudo-code lays out the steps taken in this procedure:
                                           overflow-trajectory overflow-heat crown-type)))
           (get-neighbors here))))
 
+(defn- get-old-fractional-distance
+  [{:keys [trajectory-combination]} {:keys [fractional-distance]} fractional-distance-matrix [i j]]
+  (if (= trajectory-combination :sum)
+    (m/mget fractional-distance-matrix i j)
+    @fractional-distance))
+
+(defn- update-fractional-distance-matrix!
+  "Update the fractional distance matrix with the largest fractional distance calculated."
+  [fractional-distance-matrix max-fractionals]
+  (doseq [[cell fractional-distance] @max-fractionals]
+    (let [[i j] cell]
+     (m/mset! fractional-distance-matrix i j fractional-distance))))
+
+(defn- update-fractional-distance!
+  "Update fractional distance for given trajectory into the current cell. Return a tuple of [old-value new-value]"
+  [{:keys [trajectory-combination] :as inputs} max-fractionals trajectory fractional-distance-matrix timestep cell]
+  (let [terrain-distance    (double (:terrain-distance trajectory))
+        spread-rate         (double (:spread-rate trajectory))
+        new-spread-fraction (/ (* spread-rate timestep) terrain-distance)
+        old-total           (get-old-fractional-distance inputs trajectory fractional-distance-matrix cell)
+        new-total           (+ old-total new-spread-fraction)]
+    (if (= trajectory-combination :sum)
+      (let [max-fractional-distance  (max (get @max-fractionals cell 0.0) new-total)]
+        (swap! max-fractionals assoc cell max-fractional-distance))
+      (vreset! (:fractional-distance trajectory) new-total))
+    [old-total new-total]))
+
+(defn- update-overflow-heat
+  [fractional-distance-matrix {:keys [cell trajectory]} fractional-distance]
+  (let [[i j] (mapv + cell trajectory)]
+    (m/mset! fractional-distance-matrix i j (- fractional-distance 1.0))))
+
 (defn identify-ignition-events
-  [ignited-cells timestep fire-spread-matrix]
-  (let [timestep (double timestep)]
-   (->> ignited-cells
-        (reduce (fn [acc trajectory]
-                  (let [{:keys
-                         [source
-                          cell
-                          fractional-distance]} trajectory
-                        [i j]                   source
-                        terrain-distance        (double (:terrain-distance trajectory))
-                        spread-rate             (double (:spread-rate trajectory))
-                        new-spread-fraction     (/ (* spread-rate timestep)  terrain-distance)
-                        ^double old-total       @fractional-distance
-                        ^double new-total       (vreset! fractional-distance
-                                                         (+ old-total new-spread-fraction))]
-                    (if (and (>= new-total 1.0)
-                             (> new-total ^double (get-in acc [cell :fractional-distance] 0.0)))
-                      (assoc! acc cell (merge trajectory {:fractional-distance  @fractional-distance
-                                                          :dt-adjusted          (* (/ (- 1.0 old-total) (- new-total old-total))
-                                                                                   timestep)
-                                                          :ignition-probability (m/mget fire-spread-matrix i j)}))
-                      acc)))
-                (transient {}))
-        persistent!
-        vals)))
+  [{:keys [trajectory-combination] :as inputs} ignited-cells timestep fire-spread-matrix fractional-distance-matrix]
+  (let [timestep        (double timestep)
+        max-fractionals (atom {})
+        ignition-events (->> ignited-cells
+                             (reduce (fn [acc trajectory]
+                                       (let [{:keys
+                                              [source
+                                               cell]}              trajectory
+                                             [i j]                 source
+                                             [^double old-total
+                                              ^double new-total] (update-fractional-distance! inputs
+                                                                                              max-fractionals
+                                                                                              trajectory
+                                                                                              fractional-distance-matrix
+                                                                                              timestep
+                                                                                              cell)]
+                                         (if (and (>= new-total 1.0)
+                                                  (> new-total ^double (get-in acc [cell :fractional-distance] 0.0)))
+                                           (do (when (= trajectory-combination :sum)
+                                                 (update-overflow-heat fractional-distance-matrix trajectory new-total))
+                                               (assoc! acc cell (merge trajectory {:fractional-distance  new-total
+                                                                                   :dt-adjusted          (* (/ (- 1.0 old-total) (- new-total old-total))
+                                                                                                           timestep)
+                                                                                   :ignition-probability (m/mget fire-spread-matrix i j)})))
+                                           acc)))
+                                     (transient {}))
+                             persistent!
+                             vals)]
+    (when (= trajectory-combination :sum) (update-fractional-distance-matrix! fractional-distance-matrix max-fractionals))
+    ignition-events))
 
 (defn update-ignited-cells
   [{:keys [landfire-rasters num-rows num-cols parallel-strategy] :as constants}
@@ -2246,7 +2283,8 @@ pseudo-code lays out the steps taken in this procedure:
            fire-line-intensity-matrix
            burn-time-matrix
            spread-rate-matrix
-           fire-type-matrix] :as matrices}
+           fire-type-matrix
+           fractional-distance-matrix] :as matrices}
    ignited-cells]
   (let [max-runtime      (double max-runtime)
         cell-size        (double cell-size)
@@ -2265,7 +2303,7 @@ pseudo-code lays out the steps taken in this procedure:
                                  (- max-runtime global-clock)
                                  dt)
              next-global-clock (+ global-clock timestep)
-             ignition-events   (identify-ignition-events ignited-cells timestep fire-spread-matrix)
+             ignition-events   (identify-ignition-events inputs ignited-cells timestep fire-spread-matrix fractional-distance-matrix)
              inputs            (perturbation/update-global-vals inputs global-clock next-global-clock)]
          ;; [{:cell :trajectory :fractional-distance
          ;;   :flame-length :fire-line-intensity} ...]
@@ -2363,7 +2401,7 @@ pseudo-code lays out the steps taken in this procedure:
                           (random-ignition/select-ignition-site inputs))))
 
 (defmethod run-fire-spread :ignition-point
-  [{:keys [landfire-rasters num-rows num-cols initial-ignition-site spotting] :as inputs}]
+  [{:keys [landfire-rasters num-rows num-cols initial-ignition-site spotting trajectory-combination] :as inputs}]
   (let [[i j]                      initial-ignition-site
         fuel-model-matrix          (:fuel-model landfire-rasters)
         fire-spread-matrix         (m/zero-matrix num-rows num-cols)
@@ -2372,7 +2410,8 @@ pseudo-code lays out the steps taken in this procedure:
         burn-time-matrix           (m/zero-matrix num-rows num-cols)
         firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
         spread-rate-matrix         (m/zero-matrix num-rows num-cols)
-        fire-type-matrix           (m/zero-matrix num-rows num-cols)]
+        fire-type-matrix           (m/zero-matrix num-rows num-cols)
+        fractional-distance-matrix (when (= trajectory-combination :sum) (m/zero-matrix num-rows num-cols))]
     (when (and (in-bounds? num-rows num-cols initial-ignition-site)
                (burnable-fuel-model? (m/mget fuel-model-matrix i j))
                (burnable-neighbors? fire-spread-matrix fuel-model-matrix
@@ -2398,11 +2437,12 @@ pseudo-code lays out the steps taken in this procedure:
                    :fire-line-intensity-matrix fire-line-intensity-matrix
                    :firebrand-count-matrix     firebrand-count-matrix
                    :burn-time-matrix           burn-time-matrix
-                   :fire-type-matrix           fire-type-matrix}
+                   :fire-type-matrix           fire-type-matrix
+                   :fractional-distance-matrix fractional-distance-matrix}
                   ignited-cells)))))
 
 (defmethod run-fire-spread :ignition-perimeter
-  [{:keys [num-rows num-cols initial-ignition-site landfire-rasters spotting] :as inputs}]
+  [{:keys [num-rows num-cols initial-ignition-site landfire-rasters spotting trajectory-combination] :as inputs}]
   (let [fire-spread-matrix         (first (m/mutable (:matrix initial-ignition-site)))
         non-zero-indices           (get-non-zero-indices fire-spread-matrix)
         perimeter-indices          (filter #(burnable-neighbors? fire-spread-matrix
@@ -2418,6 +2458,7 @@ pseudo-code lays out the steps taken in this procedure:
             firebrand-count-matrix     (when spotting (m/zero-matrix num-rows num-cols))
             spread-rate-matrix         (initialize-matrix num-rows num-cols non-zero-indices)
             fire-type-matrix           (initialize-matrix num-rows num-cols non-zero-indices)
+            fractional-distance-matrix (when (= trajectory-combination :sum) (initialize-matrix num-rows num-cols non-zero-indices))
             ignited-cells              (generate-ignited-cells inputs fire-spread-matrix perimeter-indices)]
         (when (seq ignited-cells)
           (run-loop inputs
@@ -2427,7 +2468,8 @@ pseudo-code lays out the steps taken in this procedure:
                      :fire-line-intensity-matrix fire-line-intensity-matrix
                      :firebrand-count-matrix     firebrand-count-matrix
                      :burn-time-matrix           burn-time-matrix
-                     :fire-type-matrix           fire-type-matrix}
+                     :fire-type-matrix           fire-type-matrix
+                     :fractional-distance-matrix fractional-distance-matrix}
                     ignited-cells))))))
 #+end_src
 

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2061,22 +2061,22 @@ pseudo-code lays out the steps taken in this procedure:
                                                  (:slope perturbations))
         ^double relative-humidity     (get-value-at here
                                                     global-clock
-                                                    (first relative-humidity)
+                                                    relative-humidity
                                                     (:relative-humidity multiplier-lookup)
                                                     (:relative-humidity perturbations))
         ^double temperature           (get-value-at here
                                                     global-clock
-                                                    (first temperature)
+                                                    temperature
                                                     (:temperature multiplier-lookup)
                                                     (:temperature perturbations))
         ^double wind-from-direction   (get-value-at here
                                                     global-clock
-                                                    (first wind-from-direction)
+                                                    wind-from-direction
                                                     (:wind-from-direction multiplier-lookup)
                                                     (:wind-from-direction perturbations))
         ^double wind-speed-20ft       (get-value-at here
                                                     global-clock
-                                                    (first wind-speed-20ft)
+                                                    wind-speed-20ft
                                                     (:wind-speed-20ft multiplier-lookup)
                                                     (:wind-speed-20ft perturbations))
         ^double fuel-moisture         (or (fuel-moisture-from-raster constants here global-clock)
@@ -2132,9 +2132,10 @@ pseudo-code lays out the steps taken in this procedure:
     [old-total new-total]))
 
 (defn- update-overflow-heat
-  [fractional-distance-matrix {:keys [cell trajectory]} fractional-distance]
-  (let [[i j] (mapv + cell trajectory)]
-    (m/mset! fractional-distance-matrix i j (- fractional-distance 1.0))))
+  [{:keys [num-rows num-cols]} fractional-distance-matrix {:keys [cell trajectory]} fractional-distance]
+  (let [[i j :as target] (mapv + cell trajectory)]
+    (when (in-bounds? num-rows num-cols target)
+     (m/mset! fractional-distance-matrix i j (- fractional-distance 1.0)))))
 
 (defn identify-ignition-events
   [{:keys [trajectory-combination] :as inputs} ignited-cells timestep fire-spread-matrix fractional-distance-matrix]
@@ -2156,10 +2157,10 @@ pseudo-code lays out the steps taken in this procedure:
                                          (if (and (>= new-total 1.0)
                                                   (> new-total ^double (get-in acc [cell :fractional-distance] 0.0)))
                                            (do (when (= trajectory-combination :sum)
-                                                 (update-overflow-heat fractional-distance-matrix trajectory new-total))
+                                                 (update-overflow-heat inputs fractional-distance-matrix trajectory new-total))
                                                (assoc! acc cell (merge trajectory {:fractional-distance  new-total
                                                                                    :dt-adjusted          (* (/ (- 1.0 old-total) (- new-total old-total))
-                                                                                                           timestep)
+                                                                                                            timestep)
                                                                                    :ignition-probability (m/mget fire-spread-matrix i j)})))
                                            acc)))
                                      (transient {}))

--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -2115,7 +2115,7 @@ pseudo-code lays out the steps taken in this procedure:
   [fractional-distance-matrix max-fractionals]
   (doseq [[cell fractional-distance] @max-fractionals]
     (let [[i j] cell]
-     (m/mset! fractional-distance-matrix i j fractional-distance))))
+      (m/mset! fractional-distance-matrix i j fractional-distance))))
 
 (defn- update-fractional-distance!
   "Update fractional distance for given trajectory into the current cell. Return a tuple of [old-value new-value]"

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -330,7 +330,7 @@
     (->> {:cell-size                 (convert/m->ft COMPUTATIONAL_DOMAIN_CELLSIZE)
           :srid                      A_SRS
           :max-runtime               (sec->min SIMULATION_TSTOP)
-          :simulations               50
+          :simulations               100
           :random-seed               SEED
           :foliar-moisture           FOLIAR_MOISTURE_CONTENT
           :ellipse-adjustment-factor 1.0

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -254,9 +254,10 @@
     [old-total new-total]))
 
 (defn- update-overflow-heat
-  [fractional-distance-matrix {:keys [cell trajectory]} fractional-distance]
-  (let [[i j] (mapv + cell trajectory)]
-    (m/mset! fractional-distance-matrix i j (- fractional-distance 1.0))))
+  [{:keys [num-rows num-cols]} fractional-distance-matrix {:keys [cell trajectory]} fractional-distance]
+  (let [[i j :as target] (mapv + cell trajectory)]
+    (when (in-bounds? num-rows num-cols target)
+     (m/mset! fractional-distance-matrix i j (- fractional-distance 1.0)))))
 
 (defn identify-ignition-events
   [{:keys [trajectory-combination] :as inputs} ignited-cells timestep fire-spread-matrix fractional-distance-matrix]
@@ -278,7 +279,7 @@
                                          (if (and (>= new-total 1.0)
                                                   (> new-total ^double (get-in acc [cell :fractional-distance] 0.0)))
                                            (do (when (= trajectory-combination :sum)
-                                                 (update-overflow-heat fractional-distance-matrix trajectory new-total))
+                                                 (update-overflow-heat inputs fractional-distance-matrix trajectory new-total))
                                                (assoc! acc cell (merge trajectory {:fractional-distance  new-total
                                                                                    :dt-adjusted          (* (/ (- 1.0 old-total) (- new-total old-total))
                                                                                                             timestep)

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -237,7 +237,7 @@
   [fractional-distance-matrix max-fractionals]
   (doseq [[cell fractional-distance] @max-fractionals]
     (let [[i j] cell]
-     (m/mset! fractional-distance-matrix i j fractional-distance))))
+      (m/mset! fractional-distance-matrix i j fractional-distance))))
 
 (defn- update-fractional-distance!
   "Update fractional distance for given trajectory into the current cell. Return a tuple of [old-value new-value]"


### PR DESCRIPTION
## Purpose

Currently Gridfire tracks fractional distances coming the 8 possible
trajectories surrounding a cell individually. Therefore there is no cumulative
effect of these trajectories. However according to Morias 2001, at the end of
each time step the fractional distance that all trajectories should use next is
the maximum of the fractional distances calculated in the current time step. 

This work implements this algorithm. Users will have the option to use either
algorithm.

## Related Issues
Closes GRID-160

## Submission Checklist
- [x] Code passes linter

## Testing