### PR TITLE
GRID-170 Create active-fire-watcher ns

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,8 @@
         sig-gis/triangulum                  {:git/url "https://github.com/sig-gis/triangulum"
                                              :sha     "3feea51ad546828cecc2bf96256534d4c0aad066"}
         org.clojure/core.async              {:mvn/version "1.3.610"}
-        com.taoensso/tufte                  {:mvn/version "2.2.0"}}
+        com.taoensso/tufte                  {:mvn/version "2.2.0"}
+        com.nextjournal/beholder            {:mvn/version "1.0.0"}}
 
  :mvn/repos {"osgeo" {:url "https://repo.osgeo.org/repository/release/"}}
 

--- a/src/gridfire/active_fire_watcher.clj
+++ b/src/gridfire/active_fire_watcher.clj
@@ -1,0 +1,40 @@
+(ns gridfire.active-fire-watcher
+  (:require [nextjournal.beholder :as beholder]
+            [clojure.core.async   :refer [>!!]])
+
+  (:import java.util.TimeZone))
+
+(def file-name-regex #"[^/]*(?=[.][a-zA-Z]+$)")
+
+(def fire-name-regex #"[a-zA-Z]*[-[a-zA-Z2-9]]*")
+
+(def ignition-time-regex #"\d{8}_\d{6}")
+
+(defn- convert-date-string
+  [date-str from-format to-format]
+  (let [in-format  (doto (java.text.SimpleDateFormat. from-format)
+                     (.setTimeZone (TimeZone/getTimeZone "UTC")))
+        out-format (doto (java.text.SimpleDateFormat. to-format)
+                     (.setTimeZone (TimeZone/getTimeZone "UTC")))]
+    (->> date-str
+         (.parse in-format)
+         (.format out-format))))
+
+(defn- parse-tar [path]
+  (let [file-name     (re-find file-name-regex path)
+        fire-name     (re-find fire-name-regex file-name)
+        ignition-time (re-find ignition-time-regex file-name)]
+    [fire-name (convert-date-string ignition-time "yyyyMMdd_HHmmss" "yyyy-MM-dd HH:mm zzz")]))
+
+(defn- handler [job-queue]
+  (fn [{:keys [type path]}]
+    (when (= type :create)
+      (let [[fire-name ignition-time] (parse-tar (.toString path))
+            job                       {:fire-name     fire-name
+                                       :ignition-time ignition-time
+                                       :type          :active-fire}]
+        (>!! job-queue job)))))
+
+(defn start! [{:keys [active-fire-dir]} job-queue]
+  (when active-fire-dir
+    (beholder/watch (handler job-queue) active-fire-dir)))

--- a/test/gridfire/active_fire_watcher_test.clj
+++ b/test/gridfire/active_fire_watcher_test.clj
@@ -1,0 +1,42 @@
+(ns gridfire.active-fire-watcher-test
+  (:require [gridfire.active-fire-watcher :refer [file-name-regex
+                                                  fire-name-regex
+                                                  ignition-time-regex]]
+            [clojure.test :refer [deftest is]]))
+
+(deftest file-name-regex-test
+
+  (is (= "nm-johnson_20210617_203600_001"
+         (->>  "nm-johnson_20210617_203600_001.tar"
+               (re-find file-name-regex))))
+
+  (is (= "nm-johnson_20210617_203600_001"
+         (->>  "/home/nm-johnson_20210617_203600_001.tar"
+               (re-find file-name-regex))))
+
+  (is (= "nm-johnson_20210617_203600_001"
+         (->>  "/gridfire/data/nm-johnson_20210617_203600_001.tar"
+               (re-find file-name-regex)))))
+
+(deftest fire-name-regex-test
+
+  (is (= "nm-johnson"
+         (->>  "nm-johnson_20210617_203600_001"
+               (re-find fire-name-regex))))
+
+  (is (= "ut-bear-bennion-creek"
+         (->>  "ut-bear-bennion-creek_20210610_184300_001"
+               (re-find fire-name-regex))))
+  (is (= "nm"
+         (->>  "nm_20210617_203600_001"
+               (re-find fire-name-regex))))
+
+  (is (= "ca-success-2"
+         (->>  "ca-success-2_20210618_000000_001.tar"
+               (re-find fire-name-regex)))))
+
+(deftest ignition-time-regex-test
+
+  (is (= "20210617_203600"
+         (->>  "nm-johnson_20210617_203600_001"
+               (re-find ignition-time-regex)))))


### PR DESCRIPTION
## Purpose

This PR creates a ns to launch a process watching a specified directory for new
files created. Upon detecting new file, a job entry will be put onto a specified
queue. This process allows us to integrate active fires into the current
match-drop server.

## Related Issues
Closes GRID-170

## Submission Checklist
- [x] Code passes linter

## Testing
test ns `gridfire.active-fire-watcher-test`