### PR TITLE
GRID-170 Use active-fire-watcher in server

### DIFF
--- a/src/gridfire/spec/server.clj
+++ b/src/gridfire/spec/server.clj
@@ -7,9 +7,9 @@
 (spec/def ::fire-name                       fire-name?)
 (spec/def ::ignition-time                   time?)
 (spec/def ::gridfire-server-request         (spec/keys :req-un [::fire-name
-                                                                ::ignition-time
-                                                                ::response-host
-                                                                ::response-port]))
+                                                                ::ignition-time]
+                                                       :req-opt [::response-host
+                                                                 ::response-port]))
 
-(spec/def ::gridfire-server-request-minimal (spec/keys :req-un [::response-host
-                                                                ::response-port]))
+(spec/def ::gridfire-server-response-minimal (spec/keys :req-un [::response-host
+                                                                 ::response-port]))


### PR DESCRIPTION
## Purpose

In order to allows active-fire requests to be handled by the server the request
spec needs to be updated so `responseHost` and `responsePort` are optional.

## Related Issues
Closes GRID-170

## Submission Checklist
- [x] Code passes linter

## Testing