### PR TITLE
GRID 170 Elmfire.data conversion misc fixes

### DIFF
--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -2,6 +2,7 @@
   (:require [clojure.pprint :as pprint]
             [clojure.string :as str]
             [clojure.tools.cli :refer [parse-opts]]
+            [clojure.java.io :as io]
             [gridfire.conversion :as convert]
             [triangulum.logging :refer [log-str]]))
 
@@ -89,10 +90,11 @@
            USE_IGNITION_MASK EDGEBUFFER IGNITION_MASK_FILENAME]}
    _
    config]
-  (let [dir FUELS_AND_TOPOGRAPHY_DIRECTORY]
+  (let [dir            FUELS_AND_TOPOGRAPHY_DIRECTORY
+        ignition-mask? (.exists (io/file (file-path dir IGNITION_MASK_FILENAME)))]
     (merge config
            (if RANDOM_IGNITIONS
-             {:random-ignition {:ignition-mask (when USE_IGNITION_MASK
+             {:random-ignition {:ignition-mask (when (and USE_IGNITION_MASK ignition-mask?)
                                                  {:type   :geotiff
                                                   :source (file-path dir IGNITION_MASK_FILENAME)})
                                 :edge-buffer   (when EDGEBUFFER

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -23,7 +23,7 @@
     (re-matches #"^\d+$" s)                (Integer/parseInt s)
     (re-matches #".TRUE." s)               true
     (re-matches #".FALSE." s)              false
-    (re-matches #"'[a-zA-Z_.//]*'" s)      (subs s 1 (dec (count s)))
+    (re-matches #"'[0-9a-zA-Z_.//]*'" s)   (subs s 1 (dec (count s)))
     :else                                  nil))
 
 (defn convert-key [s]

--- a/src/gridfire/config.clj
+++ b/src/gridfire/config.clj
@@ -23,7 +23,8 @@
     (re-matches #"^\d+$" s)                (Integer/parseInt s)
     (re-matches #".TRUE." s)               true
     (re-matches #".FALSE." s)              false
-    :else                                  (subs s 1 (dec (count s)))))
+    (re-matches #"'[a-zA-Z_.//]*'" s)      (subs s 1 (dec (count s)))
+    :else                                  nil))
 
 (defn convert-key [s]
   (if (re-matches regex-for-array-item s)
@@ -328,7 +329,7 @@
    options]
   (let [data (into (sorted-map ) d)]
     (->> {:cell-size                 (convert/m->ft COMPUTATIONAL_DOMAIN_CELLSIZE)
-          :srid                      A_SRS
+          :srid                      (or A_SRS "EPSG:32610")
           :max-runtime               (sec->min SIMULATION_TSTOP)
           :simulations               100
           :random-seed               SEED


### PR DESCRIPTION
## Purpose

- Add default values when values missing from elmfire.data
- Ignore ignition-mask if file is missing

## Related Issues
Closes GRID-170

## Submission Checklist
- [x] Code passes linter

## Testing