### PR TITLE
GRID-170 Send geosync request to register layer for active fires

### DIFF
--- a/src/gridfire/active_fire_watcher.clj
+++ b/src/gridfire/active_fire_watcher.clj
@@ -1,5 +1,6 @@
 (ns gridfire.active-fire-watcher
   (:require [nextjournal.beholder :as beholder]
+            [triangulum.logging   :refer [log-str]]
             [clojure.core.async   :refer [>!! go >!]])
 
   (:import java.util.TimeZone))
@@ -28,6 +29,7 @@
 
 (defn- handler [job-queue]
   (fn [{:keys [type path]}]
+    (log-str "Active Fire input deck detected: " type ":" (.toString path))
     (go
      (when (= type :create)
        (let [[fire-name ignition-time] (parse-tar (.toString path))


### PR DESCRIPTION
## Purpose

For Active fires, we need to send a geosync request to register layers, unlike
match drop which let's pyregence handles it.

## Related Issues
Closes GRID-170

## Submission Checklist
- [x] Code passes linter

## Testing