### PR TITLE
GRID-172 Check for valid ignition-sites before running simulations

### DIFF
--- a/org/GridFire.org
+++ b/org/GridFire.org
@@ -1897,7 +1897,6 @@ pseudo-code lays out the steps taken in this procedure:
             [gridfire.fuel-models         :refer [build-fuel-model moisturize]]
             [gridfire.perturbation        :as perturbation]
             [gridfire.utils.primitive     :refer [double-reduce]]
-            [gridfire.random-ignition     :as random-ignition]
             [gridfire.spotting            :as spot]
             [gridfire.surface-fire        :refer [anderson-flame-depth
                                                   byram-fire-line-intensity
@@ -1905,7 +1904,8 @@ pseudo-code lays out the steps taken in this procedure:
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]))
+                                                  wind-adjustment-factor]]
+            [gridfire.utils.random        :as random]))
 
 (m/set-current-implementation :vectorz)
 
@@ -2357,10 +2357,11 @@ pseudo-code lays out the steps taken in this procedure:
       :random-ignition-point)))
 
 (defmethod run-fire-spread :random-ignition-point
-  [inputs]
+  [{:keys [ignitable-sites rand-gen] :as inputs}]
+  (.nextDouble rand-gen)
   (run-fire-spread (assoc inputs
                           :initial-ignition-site
-                          (random-ignition/select-ignition-site inputs))))
+                          (random/my-rand-nth rand-gen ignitable-sites))))
 
 (defmethod run-fire-spread :ignition-point
   [{:keys [landfire-rasters num-rows num-cols initial-ignition-site spotting] :as inputs}]
@@ -3094,28 +3095,29 @@ or false:
 #+begin_src clojure :results silent :exports code :tangle ../src/gridfire/cli.clj :padline no :no-expand :comments link
 (ns gridfire.cli
   (:gen-class)
-  (:require [clojure.core.matrix    :as m]
-            [clojure.core.reducers  :as r]
-            [clojure.data.csv       :as csv]
-            [clojure.edn            :as edn]
-            [clojure.java.io        :as io]
-            [clojure.spec.alpha     :as s]
-            [clojure.string         :as str]
-            [gridfire.binary-output :as binary]
-            [gridfire.common        :refer [calc-emc get-neighbors in-bounds?]]
-            [gridfire.crown-fire    :refer [m->ft]]
-            [gridfire.fetch         :as fetch]
-            [gridfire.fire-spread   :refer [run-fire-spread]]
-            [gridfire.perturbation  :as perturbation]
-            [gridfire.spec.config   :as spec]
-            [gridfire.utils.random  :refer [draw-samples]]
-            [magellan.core          :refer [make-envelope
-                                            matrix-to-raster
-                                            register-new-crs-definitions-from-properties-file!
-                                            write-raster]]
-            [matrix-viz.core        :refer [save-matrix-as-png]]
-            [taoensso.tufte         :as tufte]
-            [triangulum.logging     :refer [log-str log]])
+  (:require [clojure.core.matrix      :as m]
+            [clojure.core.reducers    :as r]
+            [clojure.data.csv         :as csv]
+            [clojure.edn              :as edn]
+            [clojure.java.io          :as io]
+            [clojure.spec.alpha       :as s]
+            [clojure.string           :as str]
+            [gridfire.binary-output   :as binary]
+            [gridfire.common          :refer [calc-emc get-neighbors in-bounds?]]
+            [gridfire.crown-fire      :refer [m->ft]]
+            [gridfire.fetch           :as fetch]
+            [gridfire.fire-spread     :refer [run-fire-spread]]
+            [gridfire.perturbation    :as perturbation]
+            [gridfire.random-ignition :as random-ignition]
+            [gridfire.spec.config     :as spec]
+            [gridfire.utils.random    :refer [draw-samples]]
+            [magellan.core            :refer [make-envelope
+                                              matrix-to-raster
+                                              register-new-crs-definitions-from-properties-file!
+                                              write-raster]]
+            [matrix-viz.core          :refer [save-matrix-as-png]]
+            [taoensso.tufte           :as tufte]
+            [triangulum.logging       :refer [log-str log]])
   (:import java.util.Random))
 
 (m/set-current-implementation :vectorz)
@@ -3423,13 +3425,33 @@ or false:
          :wind-speeds-20ft     (get-weather inputs rand-gen :wind-speed-20ft weather-layers)
          :wind-from-directions (get-weather inputs rand-gen :wind-from-direction weather-layers)))
 
+(defn add-ignitable-sites
+  [{:keys [ignition-mask-layer num-rows num-cols] :as inputs}]
+  (let [ignition-mask-indices (some->> ignition-mask-layer
+                                       :matrix
+                                       first
+                                       m/non-zero-indices
+                                       (map-indexed (fn [i v] (when (pos? (count v)) [i v])))
+                                       (filterv identity))
+        ignitable-sites (if ignition-mask-indices
+                          (for [[row cols] ignition-mask-indices
+                                col        cols
+                                :when      (random-ignition/valid-ignition-site? inputs row col)]
+                            [row col])
+                          (for [row   (range num-rows)
+                                col   (range num-cols)
+                                :when (random-ignition/valid-ignition-site? inputs row col)]
+                            [row col]))]
+    (assoc inputs :ignitable-sites ignitable-sites)))
+
 (defn load-inputs
   [config]
   (-> config
       (add-input-layers)
       (add-misc-params)
       (add-sampled-params)
-      (add-weather-params)))
+      (add-weather-params)
+      (add-ignitable-sites)))
 
 ;; FIXME: Replace input-variations expression with add-sampled-params
 ;;        and add-weather-params (and remove them from load-inputs).
@@ -3576,11 +3598,13 @@ or false:
     (let [config (edn/read-string (slurp config-file))]
       (if-not (s/valid? ::spec/config config)
         (s/explain ::spec/config config)
-        (let [inputs  (load-inputs config)
-              outputs (run-simulations! inputs)]
-          (write-landfire-layers! inputs)
-          (write-burn-probability-layer! inputs outputs)
-          (write-csv-outputs! inputs outputs))))))
+        (let [inputs  (load-inputs config)]
+          (if (seq (:ignitable-sites inputs))
+            (let [outputs (run-simulations! inputs)]
+              (write-landfire-layers! inputs)
+              (write-burn-probability-layer! inputs outputs)
+              (write-csv-outputs! inputs outputs))
+            (log-str "Could not run simulation. No valid ignition sites. Config:" config-file)))))))
 #+end_src
 
 #+name: utils-random

--- a/src/gridfire/fire_spread.clj
+++ b/src/gridfire/fire_spread.clj
@@ -19,7 +19,6 @@
             [gridfire.fuel-models         :refer [build-fuel-model moisturize]]
             [gridfire.perturbation        :as perturbation]
             [gridfire.utils.primitive     :refer [double-reduce]]
-            [gridfire.random-ignition     :as random-ignition]
             [gridfire.spotting            :as spot]
             [gridfire.surface-fire        :refer [anderson-flame-depth
                                                   byram-fire-line-intensity
@@ -27,7 +26,8 @@
                                                   rothermel-surface-fire-spread-any
                                                   rothermel-surface-fire-spread-max
                                                   rothermel-surface-fire-spread-no-wind-no-slope
-                                                  wind-adjustment-factor]]))
+                                                  wind-adjustment-factor]]
+            [gridfire.utils.random        :as random]))
 
 (m/set-current-implementation :vectorz)
 
@@ -479,10 +479,11 @@
       :random-ignition-point)))
 
 (defmethod run-fire-spread :random-ignition-point
-  [inputs]
+  [{:keys [ignitable-sites rand-gen] :as inputs}]
+  (.nextDouble rand-gen)
   (run-fire-spread (assoc inputs
                           :initial-ignition-site
-                          (random-ignition/select-ignition-site inputs))))
+                          (random/my-rand-nth rand-gen ignitable-sites))))
 
 (defmethod run-fire-spread :ignition-point
   [{:keys [landfire-rasters num-rows num-cols initial-ignition-site spotting] :as inputs}]

--- a/src/gridfire/random_ignition.clj
+++ b/src/gridfire/random_ignition.clj
@@ -1,8 +1,7 @@
 ;; [[file:../../org/GridFire.org::random_ignition.clj][random_ignition.clj]]
 (ns gridfire.random-ignition
-  (:require [clojure.core.matrix    :as m]
-            [gridfire.utils.random :as random]
-            [gridfire.common :refer [burnable-fuel-model? get-neighbors]]))
+  (:require [clojure.core.matrix :as m]
+            [gridfire.common     :refer [burnable-fuel-model?]]))
 
 (defn- in-edge-buffer?
   "Returns true if give [row col] is within the buffer region defined
@@ -21,31 +20,4 @@
            (let [buffer-size (int (Math/ceil (/ edge-buffer cell-size)))]
              (not (in-edge-buffer? num-rows num-cols buffer-size row col)))
            true)
-         (burnable-fuel-model? (m/mget fuel-model row col))
-         (some (fn [[row col]]
-                 (burnable-fuel-model? (m/mget fuel-model row col)))
-               (get-neighbors [row col])))))
-
-(defn select-ignition-site
-  "Returns [x y] coordinate that have been randomly sampled
-  from cells in in the computational domain. Ignitable cells can also
-  be constrained by ignition mask raster and/or edge-buffer."
-  [{:keys [rand-gen ignition-mask-layer num-rows num-cols] :as inputs}]
-  (if-let [indices (some->> ignition-mask-layer
-                            :matrix
-                            first
-                            m/non-zero-indices
-                            (map-indexed (fn [i v] (when (pos? (count v)) [i v])))
-                            (filterv identity))]
-    (loop [[row cols] (random/my-rand-nth rand-gen indices)]
-      (let [col (random/my-rand-nth rand-gen cols)]
-        (if (valid-ignition-site? inputs row col)
-          [row col]
-          (recur (random/my-rand-nth rand-gen indices)))))
-    (loop [row (random/my-rand-int rand-gen num-rows)
-           col (random/my-rand-int rand-gen num-cols)]
-      (if (valid-ignition-site? inputs row col)
-        [row col]
-        (recur (random/my-rand-int rand-gen num-rows)
-               (random/my-rand-int rand-gen num-cols))))))
-;; random_ignition.clj ends here
+         (burnable-fuel-model? (m/mget fuel-model row col)))))


### PR DESCRIPTION
## Purpose

When using an ignition-mask raster GRIDFIRE’s chooses random ignition sites
assuming there is at least one cell that has a burnable fuel model number. When
given an ignition mask that does not have any valid ignition sites, the process
to choose an ignition point enters an infinite loop. This PR fixes this, by
preprocessing the valid ignition site during the load-inputs phase.

## Related Issues
Closes GRID-172

## Submission Checklist
- [x] Code passes linter

## Testing