### PR TITLE
GRID-174 Add --no-overwrite-dir option to tar extraction process

### DIFF
--- a/resources/upload_tarball.sh
+++ b/resources/upload_tarball.sh
@@ -13,6 +13,6 @@ mv *.tar ..
 echo "Extracting tarball on data.pyregence.org"
 ssh gridfire@data.pyregence.org \
     tar -xf /incoming/match_drop/$MODEL-$FIRENAME-${START_DATE}_${START_TIME}.tar \
-    -C /var/www/html/fire_spread_forecast
+    -C /var/www/html/fire_spread_forecast --no-overwrite-dir
 
 exit 0


### PR DESCRIPTION
## Purpose

Remove errors from logs when extracting tarball to geoserver:
`Cannot utime: Operation not permitted`


## Related Issues
Closes GRID-174

## Submission Checklist
- [x] Code passes linter

## Testing